### PR TITLE
Fix Vercel NOT_FOUND error by removing /public/ prefix from rewrites

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,15 +2,11 @@
   "rewrites": [
     {
       "source": "/",
-      "destination": "/public/welcome-v2.html"
+      "destination": "/welcome-v2.html"
     },
     {
       "source": "/api/(.*)",
       "destination": "/api/$1"
-    },
-    {
-      "source": "/(.*)",
-      "destination": "/public/$1"
     }
   ],
   "headers": [


### PR DESCRIPTION
Root cause: Vercel automatically serves files from /public/ directory at the root level of the deployed site. The rewrites were adding an extra /public/ prefix, creating paths like /public/public/welcome-v2.html which don't exist, resulting in 404 errors.

Changes:
- Changed "/" rewrite from "/public/welcome-v2.html" to "/welcome-v2.html"
- Removed redundant "/(.*)" → "/public/$1" rewrite (Vercel serves static files automatically)
- API routes rewrite unchanged (correctly points to /api/ directory)

This aligns with Vercel's convention where /public/ directory contents are promoted to the web root during deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)