### PR TITLE
Fix column name mismatch in chat_messages inserts

### DIFF
--- a/api/bestie-chat.js
+++ b/api/bestie-chat.js
@@ -143,7 +143,7 @@ Respond directly - no special formatting needed.`
           wedding_id: membership.wedding_id,
           user_id: user.id,
           role: 'user',
-          content: message,
+          message: message,
           message_type: 'bestie'
         });
 
@@ -158,7 +158,7 @@ Respond directly - no special formatting needed.`
           wedding_id: membership.wedding_id,
           user_id: user.id,
           role: 'assistant',
-          content: assistantMessage,
+          message: assistantMessage,
           message_type: 'bestie'
         });
 

--- a/api/chat.js
+++ b/api/chat.js
@@ -225,7 +225,7 @@ ONLY include fields that were mentioned in the message. If nothing was mentioned
           wedding_id: membership.wedding_id,
           user_id: user.id,
           role: 'user',
-          content: message,
+          message: message,
           message_type: 'main'
         });
 
@@ -240,7 +240,7 @@ ONLY include fields that were mentioned in the message. If nothing was mentioned
           wedding_id: membership.wedding_id,
           user_id: user.id,
           role: 'assistant',
-          content: assistantMessage,
+          message: assistantMessage,
           message_type: 'main'
         });
 

--- a/public/bestie-v2.html
+++ b/public/bestie-v2.html
@@ -203,11 +203,11 @@
                 if (error) throw error;
 
                 conversationHistory = messages || [];
-                
+
                 // Display messages
                 messages.forEach(msg => {
                     if (msg.role === 'user' || msg.role === 'assistant') {
-                        displayMessage(msg.content, msg.role);
+                        displayMessage(msg.message, msg.role);
                     }
                 });
             } catch (error) {

--- a/public/dashboard-v2.html
+++ b/public/dashboard-v2.html
@@ -206,11 +206,11 @@
                 if (error) throw error;
 
                 conversationHistory = messages || [];
-                
+
                 // Display messages
                 messages.forEach(msg => {
                     if (msg.role === 'user' || msg.role === 'assistant') {
-                        displayMessage(msg.content, msg.role);
+                        displayMessage(msg.message, msg.role);
                     }
                 });
             } catch (error) {


### PR DESCRIPTION
PROBLEM:
Database table uses column name 'message' but API was inserting 'content', causing 400 errors when trying to save chat messages.

SOLUTION:
- Changed chat.js insert from 'content' to 'message'
- Changed bestie-chat.js insert from 'content' to 'message'
- Updated dashboard-v2.html to read msg.message instead of msg.content
- Updated bestie-v2.html to read msg.message instead of msg.content

Chat messages should now save successfully to the database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)