### PR TITLE
Fix wedding creation: Remove non-existent bestie_addon_enabled column

### DIFF
--- a/api/create-wedding.js
+++ b/api/create-wedding.js
@@ -94,8 +94,8 @@ export default async function handler(req, res) {
       trial_start_date: new Date().toISOString(),
       trial_end_date: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(), // 7 day trial
       plan_type: 'trial',
-      subscription_status: 'trialing',
-      bestie_addon_enabled: true  // Include 1 bestie invite in free trial
+      subscription_status: 'trialing'
+      // Note: bestie_addon_enabled column removed - not in current schema
     };
 
     // Add optional fields


### PR DESCRIPTION
Fixed critical database schema error preventing wedding profile creation.

The Error:
"Could not find the 'bestie_addon_enabled' column of 'wedding_profiles' in the schema cache"

Root Cause:
- api/create-wedding.js line 98 was setting bestie_addon_enabled: true
- This column doesn't exist in the current wedding_profiles table schema
- Caused wedding creation to fail for ALL users completing onboarding

The Fix:
Removed the bestie_addon_enabled field from the weddingData object in api/create-wedding.js. The wedding profile now creates successfully with only the columns that actually exist in the database:
- owner_id
- trial_start_date
- trial_end_date
- plan_type
- subscription_status
- (plus optional fields like wedding_name, wedding_date, etc.)

Impact:
✅ Wedding creation now works for both "Yes" and "No" paths in onboarding ✅ Users can complete onboarding without database errors ✅ Trial weddings still created correctly with 7-day trial period

Testing:
- Onboarding flow → Click "No" on planning question → Wedding creates ✅
- Onboarding flow → Click "Yes" on planning question → Wedding creates ✅

Note: If bestie addon functionality is needed, the column should be added to the wedding_profiles table schema via a migration, then this field can be re-enabled in the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)