### PR TITLE
Fix wedding onboarding flow to save all collected data

### DIFF
--- a/api/create-wedding.js
+++ b/api/create-wedding.js
@@ -30,7 +30,11 @@ export default async function handler(req, res) {
     expectedGuestCount,
     totalBudget,
     weddingStyle,
-    colorSchemePrimary
+    colorSchemePrimary,
+    // Onboarding fields
+    engagementDate,
+    startedPlanning,
+    planningCompleted
   } = req.body;
 
   // ========================================================================
@@ -113,6 +117,11 @@ export default async function handler(req, res) {
     if (totalBudget) weddingData.total_budget = parseFloat(totalBudget);
     if (weddingStyle) weddingData.wedding_style = weddingStyle;
     if (colorSchemePrimary) weddingData.color_scheme_primary = colorSchemePrimary;
+
+    // Add onboarding fields
+    if (engagementDate) weddingData.engagement_date = engagementDate;
+    if (startedPlanning !== undefined) weddingData.started_planning = startedPlanning;
+    if (planningCompleted) weddingData.planning_completed = JSON.stringify(planningCompleted);
 
     // ========================================================================
     // STEP 5: Create wedding profile

--- a/database_init.sql
+++ b/database_init.sql
@@ -872,6 +872,50 @@ CREATE TRIGGER trigger_update_wedding_profiles_updated_at
   EXECUTE FUNCTION update_wedding_profiles_updated_at();
 
 -- ============================================================================
+-- STEP 11: ADD ENGAGEMENT DATE AND ONBOARDING DATA
+-- ============================================================================
+-- Source: migrations/008_add_engagement_and_onboarding_data.sql
+-- Adds columns to store onboarding data collected during signup
+-- ============================================================================
+
+-- Add engagement date column
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'wedding_profiles' AND column_name = 'engagement_date'
+  ) THEN
+    ALTER TABLE wedding_profiles ADD COLUMN engagement_date DATE;
+  END IF;
+END $$;
+
+-- Add started_planning column (tracks if they answered "yes" to planning)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'wedding_profiles' AND column_name = 'started_planning'
+  ) THEN
+    ALTER TABLE wedding_profiles ADD COLUMN started_planning BOOLEAN DEFAULT false;
+  END IF;
+END $$;
+
+-- Add planning_completed column (stores array of completed planning items)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'wedding_profiles' AND column_name = 'planning_completed'
+  ) THEN
+    ALTER TABLE wedding_profiles ADD COLUMN planning_completed JSONB DEFAULT '[]'::jsonb;
+  END IF;
+END $$;
+
+-- Add index on engagement_date for sorting/filtering
+CREATE INDEX IF NOT EXISTS wedding_profiles_engagement_date_idx
+ON wedding_profiles(engagement_date);
+
+-- ============================================================================
 -- DEPLOYMENT COMPLETE
 -- ============================================================================
 

--- a/migrations/008_add_engagement_and_onboarding_data.sql
+++ b/migrations/008_add_engagement_and_onboarding_data.sql
@@ -1,0 +1,49 @@
+-- ============================================================================
+-- MIGRATION 008: Add Engagement Date and Onboarding Data
+-- ============================================================================
+-- Adds columns to store onboarding data collected during signup
+-- ============================================================================
+
+-- Add engagement date column
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'wedding_profiles' AND column_name = 'engagement_date'
+  ) THEN
+    ALTER TABLE wedding_profiles ADD COLUMN engagement_date DATE;
+  END IF;
+END $$;
+
+-- Add started_planning column (tracks if they answered "yes" to planning)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'wedding_profiles' AND column_name = 'started_planning'
+  ) THEN
+    ALTER TABLE wedding_profiles ADD COLUMN started_planning BOOLEAN DEFAULT false;
+  END IF;
+END $$;
+
+-- Add planning_completed column (stores array of completed planning items)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'wedding_profiles' AND column_name = 'planning_completed'
+  ) THEN
+    ALTER TABLE wedding_profiles ADD COLUMN planning_completed JSONB DEFAULT '[]'::jsonb;
+  END IF;
+END $$;
+
+-- Add index on engagement_date for sorting/filtering
+CREATE INDEX IF NOT EXISTS wedding_profiles_engagement_date_idx
+ON wedding_profiles(engagement_date);
+
+-- ============================================================================
+-- VERIFICATION
+-- ============================================================================
+SELECT
+  '✓ Migration 008 Complete' as status,
+  'Added engagement_date, started_planning, planning_completed columns' as changes;

--- a/public/onboarding-luxury.html
+++ b/public/onboarding-luxury.html
@@ -578,13 +578,19 @@
                     userToken: session.access_token,
                     // Map onboarding data to API expected fields
                     coupleNames: onboardingData.aboutUs || onboardingData.fullName,
-                    // Note: We don't have wedding date from onboarding, only engagement date
-                    // The API will create a wedding profile with trial status
+                    engagementDate: onboardingData.engagementDate,
+                    startedPlanning: onboardingData.startedPlanning,
+                    planningCompleted: onboardingData.planningCompleted,
+                    // Note: We collect engagement date in onboarding
+                    // Wedding date will be collected through chat conversation
                 };
 
                 // Log what we're sending (excluding sensitive data)
                 console.log('📤 Sending wedding creation request with data:', {
                     coupleNames: requestData.coupleNames,
+                    engagementDate: requestData.engagementDate,
+                    startedPlanning: requestData.startedPlanning,
+                    planningCompleted: requestData.planningCompleted,
                     userTokenPresent: !!requestData.userToken
                 });
 


### PR DESCRIPTION
PROBLEM:
- User onboarding collected engagement date, planning status, and checklist data
- This data was NOT being saved to wedding_profile or wedding_members tables
- Only couple names were being sent to create-wedding API

SOLUTION:
1. Added database migration 008 to add missing columns:
   - engagement_date (DATE) - stores when couple got engaged
   - started_planning (BOOLEAN) - tracks if user has started planning
   - planning_completed (JSONB) - stores array of completed planning items

2. Updated onboarding component (public/onboarding-luxury.html):
   - Now sends all collected data: engagementDate, startedPlanning, planningCompleted
   - Added logging for debugging the complete data being sent

3. Updated create-wedding API (api/create-wedding.js):
   - Accepts new onboarding fields from request body
   - Stores engagement date and planning data in wedding_profile table

4. Updated database_init.sql master script:
   - Includes migration 008 for complete database setup

RESULT:
- Complete onboarding data flow: collection → submission → storage
- Wedding profiles now capture full onboarding context
- wedding_members table already working (creates owner entry correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)