### PR TITLE
Remove paywall gating from bestie experience

### DIFF
--- a/api/bestie-chat.js
+++ b/api/bestie-chat.js
@@ -50,18 +50,6 @@ export default async function handler(req, res) {
 
     if (weddingError || !weddingData) throw new Error('Wedding profile not found');
 
-    // Check trial/VIP status
-    const now = new Date();
-    const trialEnds = weddingData.trial_end_date ? new Date(weddingData.trial_end_date) : null;
-    const isVip = weddingData.is_vip;
-
-    if (trialEnds && now > trialEnds && !isVip) {
-      return res.status(200).json({
-        response: "Your trial has ended, bestie! 💕\n\nUpgrade to VIP to keep chatting with me!\n\nHead to the upgrade page and I'll be here waiting for you!",
-        trialExpired: true
-      });
-    }
-
     // Build wedding context for bestie chat with extraction
     let weddingContext = `You are Bestie Buddy, the AI assistant for the Maid of Honor, Best Man, or Best Friend helping plan wedding events.
 

--- a/public/bestie-luxury.html
+++ b/public/bestie-luxury.html
@@ -193,15 +193,6 @@
                 const { wedding, weddingId: loadedWeddingId, member } = await loadWeddingData();
                 weddingId = loadedWeddingId;
 
-                // Bestie-specific checks
-                if (!wedding.bestie_addon_enabled) {
-                    showToast('Bestie planning is not included in your current plan. Please upgrade to access this feature.', 'error');
-                    setTimeout(() => {
-                        window.location.href = `dashboard-luxury.html?wedding_id=${weddingId}`;
-                    }, 3000);
-                    return;
-                }
-
                 // Verify user has bestie role
                 if (member.role !== 'bestie' && member.role !== 'owner') {
                     showToast('You do not have access to Bestie planning.', 'error');


### PR DESCRIPTION
## Summary
- remove the bestie add-on gate from the bestie planning page so invited besties can access their space without upgrade prompts
- drop the trial/VIP paywall check from the bestie chat API so invited besties can always chat once authenticated

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ffaa0ffcfc8320bfe6e113620f4d0d