### PR TITLE
Replace text-based logo with official logo image across all pages

### DIFF
--- a/public/index-luxury.html
+++ b/public/index-luxury.html
@@ -28,10 +28,7 @@
 
             <!-- Logo -->
             <div class="animate-fade-in" style="margin-bottom: var(--space-12); text-align: center;">
-                <h1 class="logo" style="font-family: var(--font-heading); font-size: var(--text-5xl); color: var(--color-gold); margin-bottom: var(--space-2); line-height: 1; text-shadow: 0 0 30px rgba(201, 169, 97, 0.6);">
-                    <span style="font-style: italic; font-weight: 400;">Bride</span>
-                    <span style="font-weight: 700; letter-spacing: 0.05em;">BUDDY</span>
-                </h1>
+                <img src="/official-logo.png" alt="Bride Buddy" style="max-width: 400px; width: 100%; height: auto; filter: drop-shadow(0 0 30px rgba(201, 169, 97, 0.4));">
             </div>
 
             <!-- Hero Card -->

--- a/public/login-luxury.html
+++ b/public/login-luxury.html
@@ -31,10 +31,7 @@
 
             <!-- Logo -->
             <div class="animate-fade-in" style="margin-bottom: var(--space-8); text-align: center;">
-                <h1 class="logo" style="font-family: var(--font-heading); font-size: var(--text-4xl); color: var(--color-gold); margin-bottom: var(--space-2); line-height: 1; text-shadow: 0 0 30px rgba(201, 169, 97, 0.6);">
-                    <span style="font-style: italic; font-weight: 400;">Bride</span>
-                    <span style="font-weight: 700; letter-spacing: 0.05em;">BUDDY</span>
-                </h1>
+                <img src="/official-logo.png" alt="Bride Buddy" style="max-width: 300px; width: 100%; height: auto; margin-bottom: var(--space-4); filter: drop-shadow(0 0 20px rgba(201, 169, 97, 0.3));">
                 <p style="font-family: var(--font-heading); font-size: var(--text-xl); color: var(--color-body); font-weight: 300; margin-top: var(--space-2);">
                     Welcome Back
                 </p>

--- a/public/signup-luxury.html
+++ b/public/signup-luxury.html
@@ -29,11 +29,8 @@
         <div class="container" style="min-height: 100vh; display: flex; flex-direction: column; justify-content: center; align-items: center; padding: var(--space-8);">
 
             <!-- Logo (links to home) -->
-            <a href="index-luxury.html" style="margin-bottom: var(--space-8); text-decoration: none;">
-                <h1 class="logo" style="font-family: var(--font-heading); font-size: var(--text-4xl); color: var(--color-gold); margin: 0; text-shadow: 0 0 30px rgba(201, 169, 97, 0.6);">
-                    <span style="font-style: italic; font-weight: 400;">Bride</span>
-                    <span style="font-weight: 700; letter-spacing: 0.05em;">BUDDY</span>
-                </h1>
+            <a href="index-luxury.html" style="margin-bottom: var(--space-8); text-decoration: none; display: block; text-align: center;">
+                <img src="/official-logo.png" alt="Bride Buddy" style="max-width: 300px; width: 100%; height: auto; filter: drop-shadow(0 0 20px rgba(201, 169, 97, 0.3));">
             </a>
 
             <!-- Signup Card -->

--- a/public/subscribe-luxury.html
+++ b/public/subscribe-luxury.html
@@ -28,10 +28,7 @@
 
             <!-- Header -->
             <div class="animate-fade-in" style="text-align: center; margin-bottom: var(--space-12);">
-                <h1 class="logo" style="font-family: var(--font-heading); font-size: var(--text-4xl); color: var(--color-gold); margin-bottom: var(--space-4); line-height: 1; text-shadow: 0 0 30px rgba(201, 169, 97, 0.6);">
-                    <span style="font-style: italic; font-weight: 400;">Bride</span>
-                    <span style="font-weight: 700; letter-spacing: 0.05em;">BUDDY</span>
-                </h1>
+                <img src="/official-logo.png" alt="Bride Buddy" style="max-width: 300px; width: 100%; height: auto; margin: 0 auto var(--space-6); filter: drop-shadow(0 0 20px rgba(201, 169, 97, 0.3));">
                 <h2 style="font-family: var(--font-heading); font-size: var(--text-3xl); color: var(--color-heading); margin-bottom: var(--space-2);">
                     Choose Your Plan
                 </h2>


### PR DESCRIPTION
Updated all public-facing pages to use /official-logo.png instead of text-based "Bride BUDDY" logo for consistent branding.

Pages updated:
- login-luxury.html: 300px max-width with drop shadow
- signup-luxury.html: 300px max-width, clickable link to home
- index-luxury.html (landing): 400px max-width with enhanced shadow
- subscribe-luxury.html: 300px max-width in header

Technical changes:
- Replaced <h1 class="logo"> with <img> tags
- Added responsive sizing (max-width + width: 100%)
- Applied filter: drop-shadow for luxury aesthetic
- Maintained fade-in animations
- Preserved accessibility with alt text

🤖 Generated with [Claude Code](https://claude.com/claude-code)