### PR TITLE
Fix over-permissive CORS configuration

### DIFF
--- a/api/_utils/rate-limiter.js
+++ b/api/_utils/rate-limiter.js
@@ -105,11 +105,13 @@ export function getClientIdentifier(req) {
 
 /**
  * CORS configuration
+ * Locked to production domain to prevent unauthorized cross-origin access
  */
 export const CORS_HEADERS = {
-  'Access-Control-Allow-Origin': '*', // In production, set this to your domain
+  'Access-Control-Allow-Origin': 'https://bridebuddyv2.vercel.app',
   'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
   'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Allow-Credentials': 'true',
   'Access-Control-Max-Age': '86400', // 24 hours
 };
 

--- a/vercel.json
+++ b/vercel.json
@@ -24,7 +24,7 @@
         },
         {
           "key": "Access-Control-Allow-Origin",
-          "value": "*"
+          "value": "https://bridebuddyv2.vercel.app"
         },
         {
           "key": "Access-Control-Allow-Methods",


### PR DESCRIPTION
Security fixes:
- Lock CORS origin to production domain (https://bridebuddyv2.vercel.app)
- Remove conflicting wildcard/credentials pairing in vercel.json
- Add Access-Control-Allow-Credentials to shared CORS helper
- Prevent unauthorized cross-origin access if tokens leak

Before:
- vercel.json: Access-Control-Allow-Origin: * with Credentials: true (browser-rejected)
- rate-limiter.js: Wildcard origin allowing any domain

After:
- Both configs locked to production domain
- Credentials properly enabled with specific origin
- Attack surface significantly reduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)