### PR TITLE
Optimize chat handlers by batching database writes

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -289,61 +289,94 @@ IMPORTANT:
       }
     }
 
-    // 2. Insert/Update vendors in vendor_tracker table
+    // 2. Insert/Update vendors in vendor_tracker table (BATCHED)
     if (extractedData.vendors && extractedData.vendors.length > 0) {
-      for (const vendor of extractedData.vendors) {
-        // Check if vendor already exists
-        const { data: existingVendor } = await supabaseService
-          .from('vendor_tracker')
-          .select('id')
-          .eq('wedding_id', membership.wedding_id)
-          .eq('vendor_type', vendor.vendor_type)
-          .ilike('vendor_name', vendor.vendor_name || '%')
-          .single();
+      // Fetch all existing vendors for this wedding in one query
+      const { data: existingVendors } = await supabaseService
+        .from('vendor_tracker')
+        .select('id, vendor_type, vendor_name')
+        .eq('wedding_id', membership.wedding_id);
 
-        if (existingVendor) {
-          // Update existing vendor
+      const existingVendorMap = new Map();
+      if (existingVendors) {
+        existingVendors.forEach(v => {
+          const key = `${v.vendor_type}:${(v.vendor_name || '').toLowerCase()}`;
+          existingVendorMap.set(key, v.id);
+        });
+      }
+
+      const vendorsToInsert = [];
+      const vendorsToUpdate = [];
+
+      for (const vendor of extractedData.vendors) {
+        const key = `${vendor.vendor_type}:${(vendor.vendor_name || '').toLowerCase()}`;
+        const existingId = existingVendorMap.get(key);
+
+        if (existingId) {
+          // Prepare for batch update
           const vendorUpdates = { ...vendor };
           delete vendorUpdates.vendor_type; // Don't change type
           delete vendorUpdates.vendor_name; // Don't change name
-
-          const { error: vendorUpdateError } = await supabaseService
-            .from('vendor_tracker')
-            .update(vendorUpdates)
-            .eq('id', existingVendor.id);
-
-          if (vendorUpdateError) {
-            console.error('Failed to update vendor:', vendorUpdateError);
-          }
+          vendorsToUpdate.push({ id: existingId, updates: vendorUpdates });
         } else {
-          // Insert new vendor
-          const { error: vendorInsertError } = await supabaseService
-            .from('vendor_tracker')
-            .insert({
-              wedding_id: membership.wedding_id,
-              ...vendor
-            });
-
-          if (vendorInsertError) {
-            console.error('Failed to insert vendor:', vendorInsertError);
-          }
+          // Prepare for batch insert
+          vendorsToInsert.push({
+            wedding_id: membership.wedding_id,
+            ...vendor
+          });
         }
+      }
+
+      // Batch insert new vendors
+      if (vendorsToInsert.length > 0) {
+        const { error: vendorInsertError } = await supabaseService
+          .from('vendor_tracker')
+          .insert(vendorsToInsert);
+
+        if (vendorInsertError) {
+          console.error('Failed to batch insert vendors:', vendorInsertError);
+        }
+      }
+
+      // Batch update existing vendors (Supabase doesn't support bulk update, so we update individually but in parallel)
+      if (vendorsToUpdate.length > 0) {
+        await Promise.all(
+          vendorsToUpdate.map(({ id, updates }) =>
+            supabaseService
+              .from('vendor_tracker')
+              .update(updates)
+              .eq('id', id)
+              .then(({ error }) => {
+                if (error) console.error('Failed to update vendor:', error);
+              })
+          )
+        );
       }
     }
 
-    // 3. Insert/Update budget items in budget_tracker table
+    // 3. Insert/Update budget items in budget_tracker table (BATCHED)
     if (extractedData.budget_items && extractedData.budget_items.length > 0) {
-      for (const budgetItem of extractedData.budget_items) {
-        // Check if budget category already exists
-        const { data: existingBudget } = await supabaseService
-          .from('budget_tracker')
-          .select('id, spent_amount')
-          .eq('wedding_id', membership.wedding_id)
-          .eq('category', budgetItem.category)
-          .single();
+      // Fetch all existing budget items for this wedding in one query
+      const { data: existingBudgets } = await supabaseService
+        .from('budget_tracker')
+        .select('id, category, spent_amount')
+        .eq('wedding_id', membership.wedding_id);
 
-        if (existingBudget) {
-          // Update existing budget category
+      const existingBudgetMap = new Map();
+      if (existingBudgets) {
+        existingBudgets.forEach(b => {
+          existingBudgetMap.set(b.category, { id: b.id, spent_amount: b.spent_amount });
+        });
+      }
+
+      const budgetsToInsert = [];
+      const budgetsToUpdate = [];
+
+      for (const budgetItem of extractedData.budget_items) {
+        const existing = existingBudgetMap.get(budgetItem.category);
+
+        if (existing) {
+          // Prepare for batch update
           const budgetUpdates = {};
 
           if (budgetItem.budgeted_amount !== null && budgetItem.budgeted_amount !== undefined) {
@@ -351,7 +384,7 @@ IMPORTANT:
           }
 
           if (budgetItem.spent_amount !== null && budgetItem.spent_amount !== undefined) {
-            budgetUpdates.spent_amount = (existingBudget.spent_amount || 0) + budgetItem.spent_amount;
+            budgetUpdates.spent_amount = (existing.spent_amount || 0) + budgetItem.spent_amount;
           }
 
           if (budgetItem.transaction_date) budgetUpdates.last_transaction_date = budgetItem.transaction_date;
@@ -360,50 +393,63 @@ IMPORTANT:
           if (budgetItem.notes) budgetUpdates.notes = budgetItem.notes;
 
           if (Object.keys(budgetUpdates).length > 0) {
-            const { error: budgetUpdateError } = await supabaseService
-              .from('budget_tracker')
-              .update(budgetUpdates)
-              .eq('id', existingBudget.id);
-
-            if (budgetUpdateError) {
-              console.error('Failed to update budget:', budgetUpdateError);
-            }
+            budgetsToUpdate.push({ id: existing.id, updates: budgetUpdates });
           }
         } else {
-          // Insert new budget category
-          const { error: budgetInsertError } = await supabaseService
-            .from('budget_tracker')
-            .insert({
-              wedding_id: membership.wedding_id,
-              category: budgetItem.category,
-              budgeted_amount: budgetItem.budgeted_amount || 0,
-              spent_amount: budgetItem.spent_amount || 0,
-              last_transaction_date: budgetItem.transaction_date,
-              last_transaction_amount: budgetItem.transaction_amount,
-              last_transaction_description: budgetItem.transaction_description,
-              notes: budgetItem.notes
-            });
-
-          if (budgetInsertError) {
-            console.error('Failed to insert budget:', budgetInsertError);
-          }
+          // Prepare for batch insert
+          budgetsToInsert.push({
+            wedding_id: membership.wedding_id,
+            category: budgetItem.category,
+            budgeted_amount: budgetItem.budgeted_amount || 0,
+            spent_amount: budgetItem.spent_amount || 0,
+            last_transaction_date: budgetItem.transaction_date,
+            last_transaction_amount: budgetItem.transaction_amount,
+            last_transaction_description: budgetItem.transaction_description,
+            notes: budgetItem.notes
+          });
         }
+      }
+
+      // Batch insert new budget items
+      if (budgetsToInsert.length > 0) {
+        const { error: budgetInsertError } = await supabaseService
+          .from('budget_tracker')
+          .insert(budgetsToInsert);
+
+        if (budgetInsertError) {
+          console.error('Failed to batch insert budgets:', budgetInsertError);
+        }
+      }
+
+      // Batch update existing budget items (in parallel)
+      if (budgetsToUpdate.length > 0) {
+        await Promise.all(
+          budgetsToUpdate.map(({ id, updates }) =>
+            supabaseService
+              .from('budget_tracker')
+              .update(updates)
+              .eq('id', id)
+              .then(({ error }) => {
+                if (error) console.error('Failed to update budget:', error);
+              })
+          )
+        );
       }
     }
 
-    // 4. Insert tasks in wedding_tasks table
+    // 4. Insert tasks in wedding_tasks table (BATCHED)
     if (extractedData.tasks && extractedData.tasks.length > 0) {
-      for (const task of extractedData.tasks) {
-        const { error: taskInsertError } = await supabaseService
-          .from('wedding_tasks')
-          .insert({
-            wedding_id: membership.wedding_id,
-            ...task
-          });
+      const tasksToInsert = extractedData.tasks.map(task => ({
+        wedding_id: membership.wedding_id,
+        ...task
+      }));
 
-        if (taskInsertError) {
-          console.error('Failed to insert task:', taskInsertError);
-        }
+      const { error: taskInsertError } = await supabaseService
+        .from('wedding_tasks')
+        .insert(tasksToInsert);
+
+      if (taskInsertError) {
+        console.error('Failed to batch insert tasks:', taskInsertError);
       }
     }
 


### PR DESCRIPTION
This change addresses sequential write loops in chat/bestie handlers that were causing N+1 query problems and inflating latency under heavier usage.

Changes:
- api/chat.js:
  * Batched vendor inserts and parallelized updates (was N queries, now 1 fetch + 1 batch insert + parallel updates)
  * Batched budget item inserts and parallelized updates (was N queries, now 1 fetch + 1 batch insert + parallel updates)
  * Batched task inserts (was N inserts, now 1 batch insert)

- api/bestie-chat.js:
  * Batched budget item inserts and parallelized updates
  * Batched task inserts

Performance improvements:
- Vendor updates: Reduced from 2N round trips to 1 + 1 + parallel updates
- Budget updates: Reduced from 2N round trips to 1 + 1 + parallel updates
- Task inserts: Reduced from N round trips to 1 batch insert
- Under load with 10 items per category, this reduces ~60 round trips to ~5

🤖 Generated with [Claude Code](https://claude.com/claude-code)