### PR TITLE
Fix Supabase SDK loading errors by adding CDN script to 7 luxury pages

### DIFF
--- a/public/accept-invite-luxury.html
+++ b/public/accept-invite-luxury.html
@@ -17,6 +17,8 @@
     <link rel="stylesheet" href="/css/styles-luxury.css">
     <link rel="stylesheet" href="/css/components-luxury.css">
 
+    <!-- Supabase -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 </head>
 <body>
     <!-- Skip to main content for accessibility -->

--- a/public/bestie-luxury.html
+++ b/public/bestie-luxury.html
@@ -17,6 +17,8 @@
     <link rel="stylesheet" href="/css/styles-luxury.css">
     <link rel="stylesheet" href="/css/components-luxury.css">
 
+    <!-- Supabase -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 </head>
 <body>
     <!-- Skip to main content for accessibility -->

--- a/public/invite-luxury.html
+++ b/public/invite-luxury.html
@@ -17,6 +17,8 @@
     <link rel="stylesheet" href="/css/styles-luxury.css">
     <link rel="stylesheet" href="/css/components-luxury.css">
 
+    <!-- Supabase -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 </head>
 <body>
     <!-- Skip to main content for accessibility -->

--- a/public/notifications-luxury.html
+++ b/public/notifications-luxury.html
@@ -17,6 +17,8 @@
     <link rel="stylesheet" href="/css/styles-luxury.css">
     <link rel="stylesheet" href="/css/components-luxury.css">
 
+    <!-- Supabase -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 </head>
 <body>
     <!-- Skip to main content for accessibility -->

--- a/public/profile-luxury.html
+++ b/public/profile-luxury.html
@@ -16,6 +16,9 @@
     <!-- Stylesheets -->
     <link rel="stylesheet" href="/css/styles-luxury.css">
     <link rel="stylesheet" href="/css/components-luxury.css">
+
+    <!-- Supabase -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 </head>
 <body>
     <!-- Skip to main content for accessibility -->

--- a/public/subscribe-luxury.html
+++ b/public/subscribe-luxury.html
@@ -17,6 +17,8 @@
     <link rel="stylesheet" href="/css/styles-luxury.css">
     <link rel="stylesheet" href="/css/components-luxury.css">
 
+    <!-- Supabase -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 </head>
 <body>
     <!-- Skip to main content for accessibility -->

--- a/public/team-luxury.html
+++ b/public/team-luxury.html
@@ -16,6 +16,9 @@
     <!-- Stylesheets -->
     <link rel="stylesheet" href="/css/styles-luxury.css">
     <link rel="stylesheet" href="/css/components-luxury.css">
+
+    <!-- Supabase -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 </head>
 <body>
     <!-- Skip to main content for accessibility -->


### PR DESCRIPTION
Previously, 7 luxury HTML files were missing the Supabase CDN script tag in their head section, causing "Supabase SDK not loaded" errors when the pages tried to initialize Supabase through shared.js.

Fixed files:
- subscribe-luxury.html (main issue reported by user)
- team-luxury.html
- profile-luxury.html
- notifications-luxury.html
- invite-luxury.html
- accept-invite-luxury.html
- bestie-luxury.html

All files now include:
<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>

This ensures the Supabase SDK loads before any JavaScript tries to use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)