### PR TITLE
Fix one-time use invite logic by removing expires_at column dependency

### DIFF
--- a/api/accept-invite.js
+++ b/api/accept-invite.js
@@ -1,8 +1,8 @@
 // ============================================================================
 // ACCEPT INVITE - UNIFIED FOR ALL ROLES
 // ============================================================================
-// Purpose: Accept invite and join wedding as partner, co-planner, or bestie
-// One-time use with expiration enforcement
+// Purpose: Accept invite and join wedding as partner or bestie
+// One-time use (no time-based expiration)
 // ============================================================================
 
 import { createClient } from '@supabase/supabase-js';
@@ -121,7 +121,7 @@ export default async function handler(req, res) {
     }
 
     // ========================================================================
-    // STEP 5: Check if invite has been used
+    // STEP 5: Check if invite has been used (one-time use only)
     // ========================================================================
     if (invite.used === true) {
       return res.status(400).json({
@@ -130,20 +130,7 @@ export default async function handler(req, res) {
     }
 
     // ========================================================================
-    // STEP 6: Check if invite has expired
-    // ========================================================================
-    const now = new Date();
-    const expiresAt = new Date(invite.expires_at);
-
-    if (expiresAt < now) {
-      return res.status(400).json({
-        error: 'This invite has expired',
-        expires_at: invite.expires_at
-      });
-    }
-
-    // ========================================================================
-    // STEP 7: Check if user is already a member of this wedding
+    // STEP 6: Check if user is already a member of this wedding
     // ========================================================================
     const { data: existingMember } = await supabaseAdmin
       .from('wedding_members')
@@ -160,7 +147,7 @@ export default async function handler(req, res) {
     }
 
     // ========================================================================
-    // STEP 8: For bestie role - check 1:1 relationship constraint
+    // STEP 7: For bestie role - check 1:1 relationship constraint
     // ========================================================================
     if (invite.role === 'bestie') {
       const { data: existingBestie } = await supabaseAdmin
@@ -180,7 +167,7 @@ export default async function handler(req, res) {
     }
 
     // ========================================================================
-    // STEP 9: Add user to wedding_members
+    // STEP 8: Add user to wedding_members
     // ========================================================================
     const { data: newMember, error: addMemberError } = await supabaseAdmin
       .from('wedding_members')
@@ -203,7 +190,7 @@ export default async function handler(req, res) {
     }
 
     // ========================================================================
-    // STEP 10: Role-specific setup
+    // STEP 9: Role-specific setup
     // ========================================================================
     if (invite.role === 'bestie') {
       // Create bestie_profile for bestie role

--- a/public/invite-luxury.html
+++ b/public/invite-luxury.html
@@ -287,7 +287,6 @@
                     .select('*')
                     .eq('wedding_id', weddingId)
                     .or('used.is.null,used.eq.false')
-                    .gt('expires_at', new Date().toISOString())
                     .order('created_at', { ascending: false });
 
                 if (error) throw error;
@@ -301,9 +300,6 @@
 
                 // SECURITY: Escape all content to prevent XSS
                 container.innerHTML = invites.map(invite => {
-                    const expiresAt = new Date(invite.expires_at);
-                    const now = new Date();
-                    const hoursLeft = Math.round((expiresAt - now) / (1000 * 60 * 60));
                     const roleDisplay = invite.role === 'partner' ? 'Partner' : 'Bestie';
                     const roleColor = invite.role === 'partner' ? 'var(--color-gold)' : 'var(--color-rust)';
 
@@ -315,7 +311,7 @@
                                 <div>
                                     <p style="font-weight: 600; color: var(--color-navy); margin-bottom: var(--space-1);">${escapeHtml(roleDisplay)}</p>
                                     <p style="font-size: var(--text-sm); color: var(--color-burgundy); opacity: 0.7;">
-                                        Expires in ${escapeHtml(hoursLeft)} hours
+                                        One-time use link
                                     </p>
                                 </div>
                                 <span style="padding: 4px 12px; background: rgba(201, 169, 97, 0.1); color: ${roleColor}; font-size: var(--text-xs); border-radius: 12px; font-weight: 500;">


### PR DESCRIPTION
**Problem:**
- Invite button was trying to create invites with an "expires_at" column that doesn't exist
- This column isn't needed for one-time use invites

**Solution:**
- Removed expires_at from invite creation (api/create-invite.js)
- Removed time-based expiration checks (api/accept-invite.js, api/get-invite-info.js)
- Updated frontend to show "One-time use link" instead of expiration time (public/invite-luxury.html)
- Invites now expire only when used (via the 'used' boolean field)

**Changes:**
1. api/create-invite.js: Remove expires_at from database insert
2. api/accept-invite.js: Remove time-based expiration validation
3. api/get-invite-info.js: Remove expires_at from query and response
4. public/invite-luxury.html: Remove expiration time display

Invites are now purely one-time use without time-based expiration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)