### PR TITLE
Fix schema mismatch: Use is_used column instead of used

### DIFF
--- a/api/accept-invite.js
+++ b/api/accept-invite.js
@@ -123,7 +123,7 @@ export default async function handler(req, res) {
     // ========================================================================
     // STEP 5: Check if invite has been used (one-time use only)
     // ========================================================================
-    if (invite.used === true) {
+    if (invite.is_used === true) {
       return res.status(400).json({
         error: 'This invite has already been used'
       });
@@ -232,7 +232,7 @@ export default async function handler(req, res) {
     const { error: updateInviteError } = await supabaseAdmin
       .from('invite_codes')
       .update({
-        used: true,
+        is_used: true,
         used_by: user.id,
         used_at: new Date().toISOString()
       })

--- a/api/get-invite-info.js
+++ b/api/get-invite-info.js
@@ -52,7 +52,7 @@ export default async function handler(req, res) {
         role,
         wedding_profile_permissions,
         created_by,
-        used,
+        is_used,
         created_at
       `)
       .eq('invite_token', invite_token)
@@ -68,7 +68,7 @@ export default async function handler(req, res) {
     // ========================================================================
     // STEP 3: Check if invite has been used (one-time use only)
     // ========================================================================
-    if (invite.used === true) {
+    if (invite.is_used === true) {
       return res.status(400).json({
         error: 'This invite has already been used',
         is_valid: false,

--- a/public/invite-luxury.html
+++ b/public/invite-luxury.html
@@ -286,7 +286,7 @@
                     .from('invite_codes')
                     .select('*')
                     .eq('wedding_id', weddingId)
-                    .or('used.is.null,used.eq.false')
+                    .or('is_used.is.null,is_used.eq.false')
                     .order('created_at', { ascending: false });
 
                 if (error) throw error;


### PR DESCRIPTION
**Root Cause:**
- Database schema uses 'is_used' column (from database_init.sql)
- API code was incorrectly using 'used' column
- This caused 400/500 errors when creating and querying invites

**Schema Analysis:**
- Base table (database_init.sql): has 'is_used' BOOLEAN
- Migration 006: Adds 'role', 'invite_token', 'wedding_profile_permissions'
- Migration 006 does NOT rename 'is_used' to 'used'

**Fixes Applied:**
1. api/create-invite.js:
   - Changed insert: used → is_used
   - Added detailed error logging for debugging
   - Added schema clarification comment

2. api/accept-invite.js:
   - Changed check: invite.used → invite.is_used
   - Changed update: used → is_used

3. api/get-invite-info.js:
   - Changed select: used → is_used
   - Changed check: invite.used → invite.is_used

4. public/invite-luxury.html:
   - Changed query filter: used.is.null,used.eq.false → is_used.is.null,is_used.eq.false

**Error Logging Enhancements:**
- Added detailed logging for wedding_members lookup failures
- Added detailed logging for wedding_profiles lookup failures
- Added detailed logging for invite_codes insert failures
- Logs now include error code, details, and hints for easier debugging

This fixes the 400/500 errors when creating invites and loading invite data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)