### PR TITLE
CRITICAL FIX: Add backward compatibility with base database schema

### DIFF
--- a/public/invite-luxury.html
+++ b/public/invite-luxury.html
@@ -335,10 +335,14 @@
 
                 // SECURITY: Escape all content to prevent XSS
                 container.innerHTML = invites.map(invite => {
-                    const roleDisplay = invite.role === 'partner' ? 'Partner' : 'Bestie';
-                    const roleColor = invite.role === 'partner' ? 'var(--color-gold)' : 'var(--color-rust)';
+                    // Base schema compatibility: role may be undefined
+                    const role = invite.role || 'partner';
+                    const roleDisplay = role === 'partner' ? 'Partner' : role === 'bestie' ? 'Bestie' : 'Team Member';
+                    const roleColor = role === 'partner' ? 'var(--color-gold)' : 'var(--color-rust)';
 
-                    const inviteUrl = sanitizeUrl(`${window.location.origin}/accept-invite-luxury.html?token=${escapeHtml(invite.invite_token)}`);
+                    // Base schema uses 'code', migration uses 'invite_token'
+                    const token = invite.invite_token || invite.code;
+                    const inviteUrl = sanitizeUrl(`${window.location.origin}/accept-invite-luxury.html?token=${escapeHtml(token)}`);
 
                     return `
                         <div style="background: rgba(255, 255, 255, 0.3); padding: var(--space-4); border-radius: var(--radius-md); margin-bottom: var(--space-3);">


### PR DESCRIPTION
The production database is using the base schema (database_init.sql) which does NOT have the columns added by migration 006. This was causing failures when trying to insert or query invite_codes.

## Base Schema Columns:
- wedding_id, code, created_by, is_used, used_by, created_at, used_at

## Migration 006 Adds (NOT in production):
- invite_token, role, wedding_profile_permissions, expires_at

## Changes Made:

### api/create-invite.js:
- Removed expires_at, invite_token, role, wedding_profile_permissions from insert
- Now only inserts base schema columns: wedding_id, code, created_by, is_used
- URL still uses ?token=XXX parameter for consistency

### api/accept-invite.js:
- Added fallback to query 'code' column when 'invite_token' not found
- Added defaults for missing role (partner) and wedding_profile_permissions
- Works with both base schema and migrated schema

### api/get-invite-info.js:
- Added fallback to query 'code' column when 'invite_token' not found
- Provides defaults for missing role and permissions fields
- Returns consistent response regardless of schema version

### public/invite-luxury.html:
- Updated to use 'code' as fallback when 'invite_token' is undefined
- Handles missing 'role' field with sensible defaults
- Displays pending invites correctly with either schema

## Result:
The invite system now works with BOTH:
- Base schema (current production)
- Migrated schema (migration 006)

No database changes required! System is fully backward compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)