### PR TITLE
CRITICAL FIX: Use public domain for invite URLs, not Vercel internal …

### DIFF
--- a/api/create-invite.js
+++ b/api/create-invite.js
@@ -204,10 +204,9 @@ export default async function handler(req, res) {
     // ========================================================================
     // STEP 7: Build invite URL
     // ========================================================================
-    const baseUrl = process.env.VERCEL_URL
-      ? `https://${process.env.VERCEL_URL}`
-      : 'https://bridebuddyv2.vercel.app';
-
+    // IMPORTANT: Do NOT use VERCEL_URL as it points to Vercel's internal deployment URLs
+    // which require Vercel authentication. Always use the public production domain.
+    const baseUrl = process.env.PUBLIC_APP_URL || 'https://bridebuddyv2.vercel.app';
     const inviteUrl = `${baseUrl}/accept-invite-luxury.html?token=${inviteToken}`;
 
     // ========================================================================


### PR DESCRIPTION
…URLs

The invite system was using process.env.VERCEL_URL which points to Vercel's internal deployment infrastructure (e.g., project-abc123.vercel.app). These URLs require Vercel account authentication, causing invite recipients to be prompted to sign up for Vercel instead of accessing the app!

Root Cause:
- VERCEL_URL is for internal Vercel deployments and preview URLs
- These are NOT publicly accessible without Vercel authentication
- Invite recipients were seeing Vercel login screens

Fix:
- Changed to use PUBLIC_APP_URL env var (if set) or hardcoded production URL
- Invite links now use: https://bridebuddyv2.vercel.app
- This is the public production domain that anyone can access

Result:
✅ Invite links now work for everyone
✅ No Vercel account required
✅ Recipients go directly to accept-invite page

🤖 Generated with [Claude Code](https://claude.com/claude-code)