### PR TITLE
CRITICAL FIX: Proper role assignment - Partner gets full access, Best…

### DIFF
--- a/api/create-invite.js
+++ b/api/create-invite.js
@@ -161,9 +161,13 @@ export default async function handler(req, res) {
     }
 
     // ========================================================================
-    // STEP 5: Generate secure invite token
+    // STEP 5: Generate secure invite token with role encoded
     // ========================================================================
-    const inviteToken = generateSecureToken();
+    // Base schema doesn't have 'role' column in invite_codes, so we encode
+    // the role in the token itself: "partner_TOKEN" or "bestie_TOKEN"
+    // This allows us to track the intended role even without the column
+    const randomToken = generateSecureToken();
+    const inviteToken = `${role}_${randomToken}`;
 
     // ========================================================================
     // STEP 6: Insert into database (base schema compatibility)

--- a/public/invite-luxury.html
+++ b/public/invite-luxury.html
@@ -335,13 +335,20 @@
 
                 // SECURITY: Escape all content to prevent XSS
                 container.innerHTML = invites.map(invite => {
-                    // Base schema compatibility: role may be undefined
-                    const role = invite.role || 'partner';
+                    // Extract role from token: "partner_TOKEN" or "bestie_TOKEN"
+                    const token = invite.invite_token || invite.code;
+                    let role = invite.role || 'partner';  // Default from database
+
+                    // If token has role encoded, extract it
+                    if (token && token.includes('_')) {
+                        const parts = token.split('_');
+                        if (parts[0] === 'partner' || parts[0] === 'bestie') {
+                            role = parts[0];
+                        }
+                    }
+
                     const roleDisplay = role === 'partner' ? 'Partner' : role === 'bestie' ? 'Bestie' : 'Team Member';
                     const roleColor = role === 'partner' ? 'var(--color-gold)' : 'var(--color-rust)';
-
-                    // Base schema uses 'code', migration uses 'invite_token'
-                    const token = invite.invite_token || invite.code;
                     const inviteUrl = sanitizeUrl(`${window.location.origin}/accept-invite-luxury.html?token=${escapeHtml(token)}`);
 
                     return `


### PR DESCRIPTION
…ie gets correct role

Fixed two major issues with invite roles:
1. Both "Invite Partner" and "Invite Bestie" were showing as "Team Member"
2. Partner invites were giving view-only access instead of full edit access

## Root Causes:

1. **No role storage in base schema**
   - Base schema has NO 'role' column in invite_codes table
   - Previous fix removed role from insert, losing all role information

2. **Invalid role in wedding_members**
   - wedding_members CHECK constraint only allows: 'owner', 'member', 'bestie'
   - API was trying to insert 'partner' role which FAILS the constraint
   - Partner invites were being rejected or defaulted to wrong role/permissions

## Solution:

### Encode role in invite token itself:
Since base schema can't store role in DB, we encode it in the token:
- Partner invites: `partner_RANDOM_TOKEN_HERE`
- Bestie invites: `bestie_RANDOM_TOKEN_HERE`

### Map roles correctly for database:
- `partner` (from token) → `member` (in DB) with `{read: true, edit: true}`
- `bestie` (from token) → `bestie` (in DB) with `{read: false, edit: false}`

## Changes Made:

### api/create-invite.js:
- Generate token with role prefix: `${role}_${randomToken}`
- Tokens now look like: "partner_abc123..." or "bestie_xyz789..."

### api/accept-invite.js:
- Extract role from token by splitting on first underscore
- Map 'partner' to 'member' role for DB insert (avoids CHECK constraint violation)
- Set permissions based on extracted role:
  - Partner: full read+edit access
  - Bestie: no wedding profile access
- Use intendedRole for display, dbRole for database operations

### api/get-invite-info.js:
- Extract role from token for display on accept page
- Show correct role badge and permissions before acceptance

### public/invite-luxury.html:
- Extract role from token when displaying pending invites
- Show "Partner" or "Bestie" correctly, not "Team Member"

## Result:

✅ "Invite Partner" creates partner links that display "Partner" ✅ "Invite Bestie" creates bestie links that display "Bestie" ✅ Partner invites give FULL edit access to wedding details ✅ Bestie invites give correct bestie role with no wedding profile access ✅ Works with base schema (no migration needed)
✅ Also works with migrated schema (uses DB role if present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)