### PR TITLE
FIX: Use 'partner' role directly in database (requires SQL update)

### DIFF
--- a/ROLE_FIX_INSTRUCTIONS.md
+++ b/ROLE_FIX_INSTRUCTIONS.md
@@ -1,0 +1,67 @@
+# Partner Role Fix Instructions
+
+## Problem
+The `wedding_members` table CHECK constraint only allowed: `'owner'`, `'member'`, `'bestie'`
+
+This caused partner invites to fail or show as "co-planner" with wrong permissions.
+
+## Solution
+Run the SQL script to add `'partner'` as a valid role.
+
+## Steps
+
+### 1. Run SQL Fix (REQUIRED)
+Open Supabase SQL Editor and run:
+```sql
+-- Drop the old CHECK constraint
+ALTER TABLE wedding_members
+DROP CONSTRAINT IF EXISTS wedding_members_role_check;
+
+-- Add new CHECK constraint with 'partner' role
+ALTER TABLE wedding_members
+ADD CONSTRAINT wedding_members_role_check
+CHECK (role IN ('owner', 'partner', 'bestie'));
+```
+
+Or simply run the file: `fix_partner_role.sql`
+
+### 2. Deploy Code Changes
+The API has been updated to use 'partner' role directly.
+Deploy the latest code from this branch.
+
+## Result
+
+After running the SQL:
+
+### Valid Roles:
+- **owner**: Wedding creator (full access)
+- **partner**: Fiancé(e) (full access - same as owner)
+- **bestie**: MOH/Best Man (bestie chat only, no wedding profile access)
+
+### Permissions:
+- Owner: `{read: true, edit: true}`
+- Partner: `{read: true, edit: true}` ✅ FULL ACCESS
+- Bestie: `{read: false, edit: false}` (bestie chat only)
+
+### What Partner Can Do:
+✅ Edit all wedding details
+✅ Manage vendors
+✅ Update budget
+✅ Assign tasks
+✅ Chat with AI
+✅ Full co-planning access
+
+## Verification
+
+After applying the fix, test:
+
+1. Create partner invite
+2. Accept invite in different browser
+3. Verify role shows as "Partner" (not "co-planner")
+4. Verify partner can EDIT wedding details
+5. Check wedding_members table shows role='partner'
+
+## Migration Note
+
+The old constraint only allowed 'member' role, which we were using for partner.
+Now we use the proper 'partner' role for clarity and correct permissions display.

--- a/fix_partner_role.sql
+++ b/fix_partner_role.sql
@@ -1,0 +1,32 @@
+-- ============================================================================
+-- FIX: Add 'partner' as valid role in wedding_members table
+-- ============================================================================
+-- This updates the CHECK constraint to allow 'partner' role
+-- Run this in Supabase SQL Editor
+-- ============================================================================
+
+-- Drop the old CHECK constraint
+ALTER TABLE wedding_members
+DROP CONSTRAINT IF EXISTS wedding_members_role_check;
+
+-- Add new CHECK constraint with 'partner' role
+ALTER TABLE wedding_members
+ADD CONSTRAINT wedding_members_role_check
+CHECK (role IN ('owner', 'partner', 'bestie'));
+
+-- Verify the constraint was updated
+SELECT
+  conname as constraint_name,
+  pg_get_constraintdef(oid) as constraint_definition
+FROM pg_constraint
+WHERE conrelid = 'wedding_members'::regclass
+  AND conname = 'wedding_members_role_check';
+
+-- ============================================================================
+-- DONE!
+-- ============================================================================
+-- After running this SQL, the wedding_members table will accept:
+--   - 'owner': Wedding creator (full access)
+--   - 'partner': Fiancé(e) (full access)
+--   - 'bestie': MOH/Best Man (bestie access only)
+-- ============================================================================


### PR DESCRIPTION
Changed system to use proper 'partner' role instead of mapping to 'member'. This ensures partner invites show correct role and permissions.

## 3 Valid Roles:
- owner: Wedding creator (full access)
- partner: Fiancé(e) (full access - same as owner)
- bestie: MOH/Best Man (bestie chat only)

## Changes Made:

### api/accept-invite.js:
- Removed mapping of partner → member
- Now inserts 'partner' role directly into wedding_members
- Owner and Partner both get full access: {read: true, edit: true}
- Updated comments to reflect partner role usage

### Database Update Required:
Created fix_partner_role.sql to update CHECK constraint:
```sql
ALTER TABLE wedding_members
DROP CONSTRAINT IF EXISTS wedding_members_role_check;

ALTER TABLE wedding_members
ADD CONSTRAINT wedding_members_role_check
CHECK (role IN ('owner', 'partner', 'bestie'));
```

### ROLE_FIX_INSTRUCTIONS.md:
Complete instructions for applying the database fix and verifying results.

## IMPORTANT:
Run fix_partner_role.sql in Supabase SQL Editor BEFORE deploying this code!

The old constraint only allowed: 'owner', 'member', 'bestie'
The new constraint allows: 'owner', 'partner', 'bestie'

Without the SQL update, partner invites will fail with CHECK constraint violation.

## Result After SQL Fix:
✅ Partner invites show as "Partner" (not "co-planner") ✅ Partner gets full edit access (same as owner)
✅ Bestie gets correct bestie-only access
✅ All three roles work properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)