### PR TITLE
FIX: Remove all 'co-planner' references from invite acceptance flow

### DIFF
--- a/api/accept-invite.js
+++ b/api/accept-invite.js
@@ -374,10 +374,11 @@ export default async function handler(req, res) {
 // ============================================================================
 // HELPER: Get role-specific success message
 // ============================================================================
+// Only 3 valid roles: owner, partner, bestie
 function getRoleMessage(role) {
   const messages = {
+    owner: 'Successfully joined as owner!',
     partner: 'Successfully joined as partner!',
-    co_planner: 'Successfully joined as co-planner!',
     bestie: 'Successfully joined as bestie!'
   };
   return messages[role] || 'Successfully joined wedding!';

--- a/api/get-invite-info.js
+++ b/api/get-invite-info.js
@@ -160,9 +160,10 @@ export default async function handler(req, res) {
       intendedRole = invite.role;
     }
 
+    // Only 3 valid roles: owner, partner, bestie
     const roleDisplayNames = {
+      owner: 'Owner',
       partner: 'Partner',
-      co_planner: 'Co-planner',
       bestie: 'Bestie (MOH/Best Man)'
     };
     const roleDisplay = roleDisplayNames[intendedRole] || 'Wedding Team Member';

--- a/public/accept-invite-luxury.html
+++ b/public/accept-invite-luxury.html
@@ -288,8 +288,13 @@
                 html += permissionItem('🤫', 'Private bestie planning space', true);
                 html += permissionItem('👁️', 'Can view wedding details', canRead);
                 html += permissionItem('✏️', 'Can edit wedding details', canEdit);
-            } else { // co_planner
-                html += permissionItem('🤝', '<strong>Co-planner Access</strong>', true);
+            } else if (inviteData.role === 'owner') {
+                html += permissionItem('👑', '<strong>Owner Access</strong>', true);
+                html += permissionItem('👁️', 'Can view and edit all wedding details', true);
+                html += permissionItem('✉️', 'Can invite and manage team members', true);
+            } else {
+                // Fallback for any unexpected role
+                html += permissionItem('👥', '<strong>Wedding Team Member</strong>', true);
                 html += permissionItem('👁️', 'Can view wedding details', canRead);
                 html += permissionItem('✏️', 'Can edit wedding details', canEdit);
             }


### PR DESCRIPTION
The accept-invite page was showing "Co-planner Access" for partner invites because of leftover co_planner role references in the code.

System now only has 3 valid roles:
- owner: Wedding creator
- partner: Fiancé(e) with full access
- bestie: MOH/Best Man with bestie-only access

## Changes:

### public/accept-invite-luxury.html:
- Removed "co_planner" case from displayPermissions()
- Added explicit "owner" case
- Updated fallback to show "Wedding Team Member"
- Partner invites now correctly show "Full Partner Access"

### api/get-invite-info.js:
- Removed 'co_planner' from roleDisplayNames
- Only includes: owner, partner, bestie
- Returns correct role display for accept page

### api/accept-invite.js:
- Removed 'co_planner' from getRoleMessage()
- Only includes: owner, partner, bestie
- Returns correct success message

## Result:
✅ Partner invite shows "Partner" with "Full Partner Access" ✅ Bestie invite shows "Bestie" with "Bestie Access" ✅ No more "co-planner" shown anywhere
✅ Accept page displays correct permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)