### PR TITLE
FIX: Implement clean 3-role system (Owner, Partner, Bestie)

### DIFF
--- a/api/accept-invite.js
+++ b/api/accept-invite.js
@@ -154,23 +154,24 @@ export default async function handler(req, res) {
       }
     }
 
-    // Override database role if present (for migrated schemas)
+    // Override with database role if present (for migrated schemas)
     if (invite.role) {
       intendedRole = invite.role;
     }
 
-    // wedding_members CHECK constraint allows: 'owner', 'partner', 'bestie'
-    // Use the intended role directly (no mapping needed)
+    // ONLY 3 valid roles: owner, partner, bestie
+    // Use the intended role directly
     const dbRole = intendedRole;
 
-    // Set permissions based on role
-    // Owner and Partner: Full access (read + edit)
-    // Bestie: No wedding profile access (bestie chat only)
+    // Set permissions based on role:
+    // - Owner: Full access (read + edit)
+    // - Partner: Full access (read + edit)
+    // - Bestie: View access (read only, no edit)
     const permissions = (intendedRole === 'owner' || intendedRole === 'partner')
-      ? { read: true, edit: true }  // Full access
+      ? { read: true, edit: true }  // Full access for owner and partner
       : intendedRole === 'bestie'
-      ? { read: false, edit: false }  // Bestie access only
-      : { read: true, edit: false };  // Default view-only
+      ? { read: true, edit: false }  // View only for bestie
+      : { read: false, edit: false };  // Default no access
 
     // Override with database permissions if present (for migrated schemas)
     const finalPermissions = invite.wedding_profile_permissions || {

--- a/api/get-invite-info.js
+++ b/api/get-invite-info.js
@@ -160,20 +160,23 @@ export default async function handler(req, res) {
       intendedRole = invite.role;
     }
 
-    // Only 3 valid roles: owner, partner, bestie
+    // ONLY 3 valid roles: owner, partner, bestie
     const roleDisplayNames = {
       owner: 'Owner',
-      partner: 'Partner',
-      bestie: 'Bestie (MOH/Best Man)'
+      partner: 'Wedding Partner',
+      bestie: 'Bestie'
     };
-    const roleDisplay = roleDisplayNames[intendedRole] || 'Wedding Team Member';
+    const roleDisplay = roleDisplayNames[intendedRole] || 'Unknown';
 
-    // Set permissions based on intended role
-    const permissions = intendedRole === 'partner'
-      ? { read: true, edit: true }  // Partner gets full access
+    // Set permissions based on role:
+    // - Owner: Full access (read + edit)
+    // - Partner: Full access (read + edit)
+    // - Bestie: View access (read only, no edit)
+    const permissions = intendedRole === 'partner' || intendedRole === 'owner'
+      ? { read: true, edit: true }  // Full access for partner and owner
       : intendedRole === 'bestie'
-      ? { read: false, edit: false }  // Bestie gets no wedding profile access
-      : { read: true, edit: false };  // Default view-only
+      ? { read: true, edit: false }  // View only for bestie
+      : { read: false, edit: false };  // Default no access
 
     // Override with database permissions if present (for migrated schemas)
     const finalPermissions = invite.wedding_profile_permissions || permissions;

--- a/migrations/021_fix_roles_owner_partner_bestie.sql
+++ b/migrations/021_fix_roles_owner_partner_bestie.sql
@@ -1,0 +1,265 @@
+-- ============================================================================
+-- MIGRATION 021: Fix Role System - Owner, Partner, Bestie ONLY
+-- ============================================================================
+-- Purpose: Clean up role system to support exactly 3 roles:
+--          - owner: Person who created the wedding
+--          - partner: Fiancé/spouse with full access
+--          - bestie: Bridesmaids/groomsmen with limited access
+--
+-- Removes: co_planner, member, team member, and all other role variations
+-- Date: 2025-10-29
+-- ============================================================================
+
+BEGIN;
+
+-- ============================================================================
+-- STEP 1: Update invite_codes table
+-- ============================================================================
+
+-- Drop old role constraint if it exists
+ALTER TABLE invite_codes DROP CONSTRAINT IF EXISTS invite_codes_role_check;
+
+-- Add new constraint: Only 'partner' and 'bestie' can be invited
+-- (owner is created during wedding creation, not via invite)
+ALTER TABLE invite_codes
+  ADD CONSTRAINT invite_codes_role_check
+  CHECK (role IN ('partner', 'bestie'));
+
+-- Update any existing 'co_planner' invites to 'bestie'
+-- (co_planner is closest to bestie functionality)
+UPDATE invite_codes
+SET role = 'bestie'
+WHERE role = 'co_planner' OR role = 'member' OR role NOT IN ('partner', 'bestie');
+
+-- Update permissions for existing invites
+-- Partner: Full access (read + edit)
+UPDATE invite_codes
+SET wedding_profile_permissions = '{"read": true, "edit": true}'::jsonb
+WHERE role = 'partner'
+  AND (wedding_profile_permissions IS NULL OR wedding_profile_permissions = '{}');
+
+-- Bestie: View only (read, no edit)
+UPDATE invite_codes
+SET wedding_profile_permissions = '{"read": true, "edit": false}'::jsonb
+WHERE role = 'bestie'
+  AND (wedding_profile_permissions IS NULL OR wedding_profile_permissions = '{}');
+
+-- ============================================================================
+-- STEP 2: Update wedding_members table
+-- ============================================================================
+
+-- Drop old role constraint if it exists
+ALTER TABLE wedding_members DROP CONSTRAINT IF EXISTS wedding_members_role_check;
+
+-- Add new constraint: Only 'owner', 'partner', 'bestie'
+ALTER TABLE wedding_members
+  ADD CONSTRAINT wedding_members_role_check
+  CHECK (role IN ('owner', 'partner', 'bestie'));
+
+-- Update any existing 'co_planner' or 'member' roles to 'bestie'
+UPDATE wedding_members
+SET role = 'bestie'
+WHERE role = 'co_planner' OR role = 'member' OR role NOT IN ('owner', 'partner', 'bestie');
+
+-- Update permissions for existing members
+-- Owner: Full access (read + edit)
+UPDATE wedding_members
+SET wedding_profile_permissions = '{"can_read": true, "can_edit": true}'::jsonb
+WHERE role = 'owner'
+  AND (wedding_profile_permissions IS NULL OR wedding_profile_permissions = '{}');
+
+-- Partner: Full access (read + edit)
+UPDATE wedding_members
+SET wedding_profile_permissions = '{"can_read": true, "can_edit": true}'::jsonb
+WHERE role = 'partner'
+  AND (wedding_profile_permissions IS NULL OR wedding_profile_permissions = '{}');
+
+-- Bestie: View only (read, no edit)
+UPDATE wedding_members
+SET wedding_profile_permissions = '{"can_read": true, "can_edit": false}'::jsonb
+WHERE role = 'bestie'
+  AND (wedding_profile_permissions IS NULL OR wedding_profile_permissions = '{}');
+
+-- ============================================================================
+-- STEP 3: Update RLS policies to use new role names
+-- ============================================================================
+
+-- Update pending_updates policy (only owner and partner can approve updates)
+DROP POLICY IF EXISTS "Owners can approve/reject updates" ON pending_updates;
+
+CREATE POLICY "Owners and partners can approve/reject updates"
+ON pending_updates FOR UPDATE
+TO authenticated
+USING (
+  wedding_id IN (
+    SELECT wedding_id
+    FROM wedding_members
+    WHERE user_id = auth.uid()
+      AND role IN ('owner', 'partner')
+  )
+)
+WITH CHECK (
+  wedding_id IN (
+    SELECT wedding_id
+    FROM wedding_members
+    WHERE user_id = auth.uid()
+      AND role IN ('owner', 'partner')
+  )
+);
+
+-- Update invite_codes policy (only owner and partner can create invites)
+DROP POLICY IF EXISTS "Wedding owners can create invites" ON invite_codes;
+
+CREATE POLICY "Owners and partners can create invites"
+  ON invite_codes FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM wedding_members wm
+      WHERE wm.wedding_id = invite_codes.wedding_id
+        AND wm.user_id = auth.uid()
+        AND wm.role IN ('owner', 'partner')
+    )
+    AND created_by = auth.uid()
+  );
+
+-- ============================================================================
+-- STEP 4: Create helper view for role information
+-- ============================================================================
+
+DROP VIEW IF EXISTS wedding_member_roles;
+
+CREATE OR REPLACE VIEW wedding_member_roles AS
+SELECT
+  wm.wedding_id,
+  wm.user_id,
+  wm.role,
+  wm.wedding_profile_permissions,
+  wm.invited_by_user_id,
+  p.full_name,
+  p.email,
+  CASE
+    WHEN wm.role = 'owner' THEN 'Owner'
+    WHEN wm.role = 'partner' THEN 'Partner'
+    WHEN wm.role = 'bestie' THEN 'Bestie'
+    ELSE 'Unknown'
+  END as role_display,
+  CASE
+    WHEN wm.role = 'owner' THEN 'Full access - Wedding creator'
+    WHEN wm.role = 'partner' THEN 'Full access - Can view and edit everything'
+    WHEN wm.role = 'bestie' THEN 'View access - Can view details, limited editing'
+    ELSE 'Unknown access'
+  END as permission_description
+FROM wedding_members wm
+LEFT JOIN profiles p ON wm.user_id = p.id;
+
+GRANT SELECT ON wedding_member_roles TO authenticated;
+
+-- ============================================================================
+-- STEP 5: Update active_invites view
+-- ============================================================================
+
+DROP VIEW IF EXISTS active_invites;
+
+CREATE OR REPLACE VIEW active_invites AS
+SELECT
+  ic.id,
+  ic.wedding_id,
+  ic.invite_token,
+  ic.role,
+  ic.wedding_profile_permissions,
+  ic.created_by,
+  ic.created_at,
+  ic.is_used,
+  ic.used_by,
+  ic.used_at,
+  wp.partner1_name,
+  wp.partner2_name,
+  CASE
+    WHEN ic.role = 'partner' THEN 'Partner'
+    WHEN ic.role = 'bestie' THEN 'Bestie'
+    ELSE 'Unknown'
+  END as role_display
+FROM invite_codes ic
+JOIN wedding_profiles wp ON ic.wedding_id = wp.id
+WHERE (ic.is_used = false OR ic.is_used IS NULL);
+
+GRANT SELECT ON active_invites TO authenticated;
+
+-- ============================================================================
+-- STEP 6: Add comments for documentation
+-- ============================================================================
+
+COMMENT ON COLUMN wedding_members.role IS 'Role of the member: owner (wedding creator), partner (fiancé/spouse), or bestie (bridesmaid/groomsman)';
+COMMENT ON COLUMN invite_codes.role IS 'Role to be assigned when invite is accepted: partner or bestie';
+
+COMMENT ON CONSTRAINT wedding_members_role_check ON wedding_members IS 'Only owner, partner, and bestie roles are allowed';
+COMMENT ON CONSTRAINT invite_codes_role_check ON invite_codes IS 'Only partner and bestie can be invited (owner is created with wedding)';
+
+-- ============================================================================
+-- VERIFICATION QUERIES
+-- ============================================================================
+
+-- Count members by role
+DO $$
+DECLARE
+  owner_count INTEGER;
+  partner_count INTEGER;
+  bestie_count INTEGER;
+  other_count INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO owner_count FROM wedding_members WHERE role = 'owner';
+  SELECT COUNT(*) INTO partner_count FROM wedding_members WHERE role = 'partner';
+  SELECT COUNT(*) INTO bestie_count FROM wedding_members WHERE role = 'bestie';
+  SELECT COUNT(*) INTO other_count FROM wedding_members WHERE role NOT IN ('owner', 'partner', 'bestie');
+
+  RAISE NOTICE 'Wedding Members Summary:';
+  RAISE NOTICE '  Owners: %', owner_count;
+  RAISE NOTICE '  Partners: %', partner_count;
+  RAISE NOTICE '  Besties: %', bestie_count;
+  RAISE NOTICE '  Other (should be 0): %', other_count;
+
+  IF other_count > 0 THEN
+    RAISE WARNING 'Found % members with invalid roles!', other_count;
+  END IF;
+END $$;
+
+-- Count invites by role
+DO $$
+DECLARE
+  partner_invite_count INTEGER;
+  bestie_invite_count INTEGER;
+  other_invite_count INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO partner_invite_count FROM invite_codes WHERE role = 'partner';
+  SELECT COUNT(*) INTO bestie_invite_count FROM invite_codes WHERE role = 'bestie';
+  SELECT COUNT(*) INTO other_invite_count FROM invite_codes WHERE role NOT IN ('partner', 'bestie');
+
+  RAISE NOTICE 'Invite Codes Summary:';
+  RAISE NOTICE '  Partner Invites: %', partner_invite_count;
+  RAISE NOTICE '  Bestie Invites: %', bestie_invite_count;
+  RAISE NOTICE '  Other (should be 0): %', other_invite_count;
+
+  IF other_invite_count > 0 THEN
+    RAISE WARNING 'Found % invite codes with invalid roles!', other_invite_count;
+  END IF;
+END $$;
+
+COMMIT;
+
+-- ============================================================================
+-- MIGRATION COMPLETE
+-- ============================================================================
+
+SELECT
+  '✓ Migration 021 Complete' as status,
+  'Role system updated: Owner, Partner, Bestie ONLY' as message;
+
+-- Summary of changes:
+-- ✅ Updated invite_codes role constraint (partner, bestie)
+-- ✅ Updated wedding_members role constraint (owner, partner, bestie)
+-- ✅ Migrated all co_planner and member roles to bestie
+-- ✅ Updated permissions for all roles
+-- ✅ Updated RLS policies for new role names
+-- ✅ Created helper views for role information
+-- ✅ Added documentation comments

--- a/public/accept-invite-luxury.html
+++ b/public/accept-invite-luxury.html
@@ -282,21 +282,16 @@
             if (inviteData.role === 'partner') {
                 html += permissionItem('👑', '<strong>Full Partner Access</strong>', true);
                 html += permissionItem('👁️', 'Can view and edit all wedding details', true);
-                html += permissionItem('✉️', 'Can invite additional team members', true);
+                html += permissionItem('✉️', 'Can invite besties', true);
             } else if (inviteData.role === 'bestie') {
                 html += permissionItem('💖', '<strong>Bestie Access</strong>', true);
                 html += permissionItem('🤫', 'Private bestie planning space', true);
                 html += permissionItem('👁️', 'Can view wedding details', canRead);
-                html += permissionItem('✏️', 'Can edit wedding details', canEdit);
+                html += permissionItem('✏️', 'Limited editing access', canEdit);
             } else if (inviteData.role === 'owner') {
                 html += permissionItem('👑', '<strong>Owner Access</strong>', true);
                 html += permissionItem('👁️', 'Can view and edit all wedding details', true);
-                html += permissionItem('✉️', 'Can invite and manage team members', true);
-            } else {
-                // Fallback for any unexpected role
-                html += permissionItem('👥', '<strong>Wedding Team Member</strong>', true);
-                html += permissionItem('👁️', 'Can view wedding details', canRead);
-                html += permissionItem('✏️', 'Can edit wedding details', canEdit);
+                html += permissionItem('✉️', 'Can invite partner and besties', true);
             }
 
             permissionsDisplay.innerHTML = html;

--- a/public/invite-luxury.html
+++ b/public/invite-luxury.html
@@ -48,7 +48,7 @@
                         Invite Your Partner
                     </h3>
                     <p style="color: var(--color-burgundy); opacity: 0.8; margin-bottom: var(--space-6);">
-                        Invite your fiancé(e) to co-manage the wedding planning. You'll both have your own AI chats that populate the same wedding details, vendors, budget, and tasks.
+                        Share full access with your fiancé(e) or spouse. You'll both have complete access to all wedding details, vendors, budget, and tasks.
                     </p>
 
                     <button
@@ -68,7 +68,7 @@
                         Invite Your Besties
                     </h3>
                     <p style="color: var(--color-burgundy); opacity: 0.8; margin-bottom: var(--space-6);">
-                        Invite your Maid of Honor or Best Man (max 2 total). Each bestie gets their own private planning space to organize bachelorette/bachelor parties and bridal showers.
+                        Invite your Maid of Honor or Best Man (max 2 total). Each bestie gets their own private planning space and can view wedding details.
                     </p>
 
                     <button
@@ -347,7 +347,7 @@
                         }
                     }
 
-                    const roleDisplay = role === 'partner' ? 'Partner' : role === 'bestie' ? 'Bestie' : 'Team Member';
+                    const roleDisplay = role === 'partner' ? 'Partner' : role === 'bestie' ? 'Bestie' : 'Unknown';
                     const roleColor = role === 'partner' ? 'var(--color-gold)' : 'var(--color-rust)';
                     const inviteUrl = sanitizeUrl(`${window.location.origin}/accept-invite-luxury.html?token=${escapeHtml(token)}`);
 


### PR DESCRIPTION
**Role Structure:**
- Owner: Person who created the wedding (full access)
- Partner: Fiancé/spouse (full access like owner)
- Bestie: Bridesmaids/groomsmen (view access + limited edit)

**Database Changes (Migration 021):**
- Update invite_codes role constraint to only allow 'partner' and 'bestie'
- Update wedding_members role constraint to only allow 'owner', 'partner', 'bestie'
- Migrate all 'co_planner' and 'member' roles to 'bestie'
- Set correct permissions for each role:
  * Owner/Partner: Full access (read + edit)
  * Bestie: View access (read only, limited edit)
- Update RLS policies for new role names
- Create helper views for role information

**Frontend Updates:**
- accept-invite-luxury.html: Update permission displays for Partner and Bestie
- invite-luxury.html: Update descriptions for Partner and Bestie invites
- Remove "team member" fallback text (replaced with "Unknown")

**API Updates:**
- accept-invite.js: Update role mapping and permissions
  * Partner: Full access (read + edit)
  * Bestie: View access (read only)
- get-invite-info.js: Update role display names
  * Partner: "Wedding Partner"
  * Bestie: "Bestie"

**Removed:**
- All references to "co_planner" role
- All references to "member" role
- "Team member" fallback displays

🤖 Generated with [Claude Code](https://claude.com/claude-code)