### PR TITLE
FIX: Remove SECURITY DEFINER from active_invites view

### DIFF
--- a/migrations/021_fix_roles_owner_partner_bestie.sql
+++ b/migrations/021_fix_roles_owner_partner_bestie.sql
@@ -190,7 +190,11 @@ GRANT SELECT ON wedding_member_roles TO authenticated;
 
 DROP VIEW IF EXISTS active_invites;
 
-CREATE OR REPLACE VIEW active_invites AS
+-- Recreate view WITHOUT security definer (uses SECURITY INVOKER by default)
+-- This ensures the view respects RLS policies and runs with user privileges
+CREATE VIEW active_invites
+WITH (security_invoker = true)
+AS
 SELECT
   ic.id,
   ic.wedding_id,
@@ -214,6 +218,8 @@ JOIN wedding_profiles wp ON ic.wedding_id = wp.id
 WHERE (ic.is_used = false OR ic.is_used IS NULL);
 
 GRANT SELECT ON active_invites TO authenticated;
+
+COMMENT ON VIEW active_invites IS 'Shows active invite codes with SECURITY INVOKER (respects RLS policies)';
 
 -- ============================================================================
 -- STEP 6: Add comments for documentation


### PR DESCRIPTION
Security Issue: active_invites view was flagged as having SECURITY DEFINER which can be a privilege escalation risk.

Solution: Explicitly create view with SECURITY INVOKER (default behavior) using WITH (security_invoker = true) clause.

Changes:
- database_init.sql: Added security_invoker = true to view definition
- migration 021: Added security_invoker = true to view definition
- Added comment explaining security model
- View now respects RLS policies and runs with user privileges

Security Impact:
✅ View respects RLS policies (no privilege escalation) ✅ Users only see invites for their own weddings
✅ No bypass of row-level security

🤖 Generated with [Claude Code](https://claude.com/claude-code)