### PR TITLE
FIX: Complete invite acceptance flow end-to-end

### DIFF
--- a/public/accept-invite-luxury.html
+++ b/public/accept-invite-luxury.html
@@ -165,14 +165,22 @@
 
         // Initialize
         async function init() {
-            // Get token from URL
+            // Get token from URL - support both 'token' and 'code' parameters for compatibility
             const urlParams = new URLSearchParams(window.location.search);
-            inviteToken = urlParams.get('token');
+            inviteToken = urlParams.get('token') || urlParams.get('code');
+
+            // Also check localStorage for invite token (in case user navigated away)
+            if (!inviteToken) {
+                inviteToken = localStorage.getItem('pending_invite_token');
+            }
 
             if (!inviteToken) {
                 showError('No invite token provided');
                 return;
             }
+
+            // Store in localStorage as backup
+            localStorage.setItem('pending_invite_token', inviteToken);
 
             // Validate invite
             await validateInvite();
@@ -221,11 +229,18 @@
             const roleBadge = document.getElementById('roleBadge');
             roleBadge.textContent = inviteData.role_display;
 
-            // Set expiration
-            const expiresIn = inviteData.days_until_expiration > 0
-                ? `${inviteData.days_until_expiration} day${inviteData.days_until_expiration !== 1 ? 's' : ''}`
-                : `${inviteData.hours_until_expiration} hour${inviteData.hours_until_expiration !== 1 ? 's' : ''}`;
-            document.getElementById('expiresIn').textContent = expiresIn;
+            // Set expiration (or hide if no expiration)
+            const expiresInElement = document.getElementById('expiresIn');
+            if (inviteData.days_until_expiration !== null && inviteData.days_until_expiration > 0) {
+                expiresInElement.textContent = `${inviteData.days_until_expiration} day${inviteData.days_until_expiration !== 1 ? 's' : ''}`;
+            } else if (inviteData.hours_until_expiration !== null && inviteData.hours_until_expiration > 0) {
+                expiresInElement.textContent = `${inviteData.hours_until_expiration} hour${inviteData.hours_until_expiration !== 1 ? 's' : ''}`;
+            } else if (inviteData.expires_at) {
+                expiresInElement.textContent = 'soon';
+            } else {
+                // No expiration set - one-time use only
+                expiresInElement.parentElement.textContent = 'One-time use only';
+            }
 
             // Display permissions
             displayPermissions();
@@ -279,9 +294,18 @@
             const { data: { session } } = await supabase.auth.getSession();
 
             if (session) {
-                // User is logged in - show accept button
-                document.getElementById('acceptPrompt').classList.remove('hidden');
-                document.getElementById('acceptBtn').addEventListener('click', acceptInvite);
+                // User is logged in - check if they just came from signup/login
+                const autoAccept = localStorage.getItem('auto_accept_invite');
+
+                if (autoAccept === 'true') {
+                    // Auto-accept the invite (user just signed up or logged in)
+                    localStorage.removeItem('auto_accept_invite');
+                    await acceptInvite();
+                } else {
+                    // Show accept button
+                    document.getElementById('acceptPrompt').classList.remove('hidden');
+                    document.getElementById('acceptBtn').addEventListener('click', acceptInvite);
+                }
             } else {
                 // User not logged in - show auth prompt with invite token in links
                 const signupLink = document.getElementById('signupLink');
@@ -298,8 +322,9 @@
 
         // Accept Invite
         async function acceptInvite() {
-            // Hide accept prompt, show processing
+            // Hide accept prompt (if visible), show processing
             document.getElementById('acceptPrompt').classList.add('hidden');
+            document.getElementById('authPrompt').classList.add('hidden');
             document.getElementById('processingState').classList.remove('hidden');
 
             try {
@@ -332,6 +357,9 @@
 
                 const result = await response.json();
 
+                // Clear pending invite token from localStorage
+                localStorage.removeItem('pending_invite_token');
+
                 // Show success
                 document.getElementById('processingState').classList.add('hidden');
                 document.getElementById('successState').classList.remove('hidden');
@@ -346,9 +374,20 @@
 
             } catch (error) {
                 console.error('Accept error:', error);
-                showError('Failed to accept invitation');
+                showToast('Failed to accept invitation. Please try again.', 'error');
                 document.getElementById('processingState').classList.add('hidden');
-                document.getElementById('acceptPrompt').classList.remove('hidden');
+
+                // Show accept button again so user can retry
+                const { data: { session } } = await supabase.auth.getSession();
+                if (session) {
+                    document.getElementById('acceptPrompt').classList.remove('hidden');
+                    // Re-attach click handler if needed
+                    const btn = document.getElementById('acceptBtn');
+                    btn.replaceWith(btn.cloneNode(true));
+                    document.getElementById('acceptBtn').addEventListener('click', acceptInvite);
+                } else {
+                    document.getElementById('authPrompt').classList.remove('hidden');
+                }
             }
         }
 

--- a/public/login-luxury.html
+++ b/public/login-luxury.html
@@ -260,6 +260,9 @@
                 if (!members || members.length === 0) {
                     // If coming from invite, return to accept-invite page
                     if (inviteToken) {
+                        // Set flag to auto-accept the invite
+                        localStorage.setItem('auto_accept_invite', 'true');
+                        localStorage.setItem('pending_invite_token', inviteToken);
                         window.location.href = `accept-invite-luxury.html?token=${inviteToken}`;
                         return;
                     }
@@ -281,6 +284,9 @@
                 // Determine redirect URL based on context
                 if (inviteToken) {
                     // User came from invite - return to accept-invite page
+                    // Set flag to auto-accept the invite
+                    localStorage.setItem('auto_accept_invite', 'true');
+                    localStorage.setItem('pending_invite_token', inviteToken);
                     window.location.href = `accept-invite-luxury.html?token=${inviteToken}`;
                 } else if (returnTo) {
                     // Custom return URL provided

--- a/public/signup-luxury.html
+++ b/public/signup-luxury.html
@@ -296,8 +296,11 @@
                 let redirectUrl;
                 if (inviteToken) {
                     // User came from invite - return to accept-invite page
+                    // Set flag to auto-accept the invite
+                    localStorage.setItem('auto_accept_invite', 'true');
+                    localStorage.setItem('pending_invite_token', inviteToken);
                     redirectUrl = `accept-invite-luxury.html?token=${inviteToken}`;
-                    showToast('success', 'Account Created!', 'Returning to invitation...');
+                    showToast('success', 'Account Created!', 'Accepting invitation...');
                 } else if (returnTo) {
                     // Custom return URL provided
                     redirectUrl = returnTo;


### PR DESCRIPTION
Critical bug fix for broken invite acceptance flow. Users were getting stuck after signup/login because they had to manually click "Accept Invitation" again.

**What was broken:**
1. User clicks invite link → create account
2. After signup, redirected to invite page
3. Invite code lost or user doesn't realize they need to click accept again
4. User stuck in loop, never gets added to wedding

**Changes:**

1. **Auto-accept after signup/login**
   - Set `auto_accept_invite` flag in localStorage after successful auth
   - Accept-invite page detects flag and automatically accepts invite
   - Eliminates manual "Accept Invitation" button click

2. **Preserve invite code with localStorage backup**
   - Store invite token in localStorage before redirecting to signup/login
   - Recover token if URL parameter is lost
   - Support both `?token=` and `?code=` parameters for compatibility

3. **Fix expiration handling**
   - Handle null `expires_at` values in get-invite-info API
   - Calculate and return days/hours until expiration
   - Show "One-time use only" when no expiration is set

4. **Better error handling**
   - Show accept button again if API call fails
   - Clear localStorage flags after successful acceptance
   - Better loading states during auto-acceptance

**New flow:**
1. User clicks invite link → create account
2. After signup, auto-redirected with localStorage flags set
3. Invite automatically accepted via API
4. User added to wedding and redirected to dashboard
5. No manual steps required!

**Files changed:**
- public/accept-invite-luxury.html (auto-accept logic, localStorage backup)
- public/signup-luxury.html (set auto_accept_invite flag)
- public/login-luxury.html (set auto_accept_invite flag)
- api/get-invite-info.js (fix expiration handling, add time calculations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)