### PR TITLE
FIX CRITICAL: Fix invite acceptance bug and add comprehensive logging

### DIFF
--- a/public/accept-invite-luxury.html
+++ b/public/accept-invite-luxury.html
@@ -322,6 +322,9 @@
 
         // Accept Invite
         async function acceptInvite() {
+            console.log('🔵 [FRONTEND] Accept invite button clicked');
+            console.log('🔵 [FRONTEND] Invite token:', inviteToken);
+
             // Hide accept prompt (if visible), show processing
             document.getElementById('acceptPrompt').classList.add('hidden');
             document.getElementById('authPrompt').classList.add('hidden');
@@ -331,9 +334,13 @@
                 const { data: { session } } = await supabase.auth.getSession();
 
                 if (!session) {
+                    console.error('❌ [FRONTEND] No session found');
                     showError('Please log in to accept this invitation');
                     return;
                 }
+
+                console.log('✅ [FRONTEND] Session found, user authenticated');
+                console.log('🔵 [FRONTEND] Calling /api/accept-invite...');
 
                 // Call accept API
                 // NOTE: No longer sending bestie_knowledge_permissions
@@ -347,8 +354,16 @@
                     })
                 });
 
+                console.log('🔵 [FRONTEND] API response status:', response.status, response.statusText);
+
                 if (!response.ok) {
                     const errorData = await response.json().catch(() => ({ error: 'Failed to accept invitation' }));
+                    console.error('❌ [FRONTEND] API returned error:', {
+                        status: response.status,
+                        statusText: response.statusText,
+                        error: errorData.error,
+                        details: errorData.details
+                    });
                     showError(errorData.error || `API error: ${response.status} ${response.statusText}`);
                     document.getElementById('processingState').classList.add('hidden');
                     document.getElementById('acceptPrompt').classList.remove('hidden');
@@ -356,6 +371,11 @@
                 }
 
                 const result = await response.json();
+                console.log('✅ [FRONTEND] Invite accepted successfully!', {
+                    wedding_id: result.wedding?.id,
+                    role: result.your_role,
+                    redirect_to: result.redirect_to
+                });
 
                 // Clear pending invite token from localStorage
                 localStorage.removeItem('pending_invite_token');
@@ -373,7 +393,10 @@
                 }, 2000);
 
             } catch (error) {
-                console.error('Accept error:', error);
+                console.error('❌ [FRONTEND] Exception during invite acceptance:', {
+                    message: error.message,
+                    stack: error.stack
+                });
                 showToast('Failed to accept invitation. Please try again.', 'error');
                 document.getElementById('processingState').classList.add('hidden');
 


### PR DESCRIPTION
**CRITICAL BUG FIXED:**
The invite acceptance was completely broken due to a database query mismatch:
- create-invite.js stores invites in the `code` column
- accept-invite.js looks up invites using both `invite_token` OR `code` columns
- When marking as used, it tried to match on `invite_token` column which doesn't exist!
- UPDATE failed silently, invite stayed is_used=false
- User was NOT added to wedding_members table

**Root Cause:**
```javascript
// ❌ WRONG - uses invite_token column which may not exist
.eq('invite_token', invite_token)

// ✅ FIXED - uses invite ID which is guaranteed to exist
.eq('id', invite.id)
```

**Changes:**

1. **Fixed UPDATE query (api/accept-invite.js:292)**
   - Changed from `.eq('invite_token', invite_token)` to `.eq('id', invite.id)`
   - Now works for both base schema and migration schemas
   - Guaranteed to mark invite as used after acceptance

2. **Added comprehensive API logging**
   - Log at every step: auth, invite lookup, member insertion, marking used
   - Color-coded logs: 🔵 info, ✅ success, ❌ error, ⚠️ warning
   - Include relevant IDs and error details for debugging
   - Format: [ACCEPT-INVITE] prefix for easy filtering

3. **Added frontend logging (accept-invite-luxury.html)**
   - Log button click, token, session check, API call, response
   - Log all errors with full details (status, message, stack)
   - Format: [FRONTEND] prefix for easy filtering

**Expected flow now:**
1. User clicks invite link → create account
2. Auto-redirected to accept-invite page
3. Invite auto-accepted via API
4. User added to wedding_members table ✅
5. Invite marked as is_used=true ✅
6. Redirect to bestie-dashboard or main dashboard

**Debugging:**
Open browser console (F12) to see detailed logs of entire flow:
- 🔵 [FRONTEND] Accept invite button clicked
- 🔵 [ACCEPT-INVITE] Starting invite acceptance process
- ✅ [ACCEPT-INVITE] User authenticated
- ✅ [ACCEPT-INVITE] Invite found
- ✅ [ACCEPT-INVITE] User added to wedding_members
- ✅ [ACCEPT-INVITE] Invite marked as used
- ✅ [FRONTEND] Invite accepted successfully!

🤖 Generated with [Claude Code](https://claude.com/claude-code)