### PR TITLE
FIX: Use showToast instead of showError for API failures

### DIFF
--- a/public/accept-invite-luxury.html
+++ b/public/accept-invite-luxury.html
@@ -335,7 +335,9 @@
 
                 if (!session) {
                     console.error('❌ [FRONTEND] No session found');
-                    showError('Please log in to accept this invitation');
+                    showToast('Please log in to accept this invitation', 'error');
+                    document.getElementById('processingState').classList.add('hidden');
+                    document.getElementById('authPrompt').classList.remove('hidden');
                     return;
                 }
 
@@ -364,7 +366,11 @@
                         error: errorData.error,
                         details: errorData.details
                     });
-                    showError(errorData.error || `API error: ${response.status} ${response.statusText}`);
+
+                    // Use showToast instead of showError to keep the page intact for retry
+                    const errorMessage = errorData.error || `API error: ${response.status} ${response.statusText}`;
+                    showToast(errorMessage, 'error', 8000);
+
                     document.getElementById('processingState').classList.add('hidden');
                     document.getElementById('acceptPrompt').classList.remove('hidden');
                     return;


### PR DESCRIPTION
**Issue:**
When API call failed during invite acceptance, `showError()` was called which:
- Hides the entire main content
- Shows a permanent error state
- User cannot retry without refreshing the page

**Fix:**
Changed to use `showToast()` for API call failures which:
- Shows a dismissable toast notification
- Keeps the "Accept Invitation" button visible
- Allows user to retry immediately
- Better UX for transient network errors

**Changes:**
1. Line 338: Use showToast + show authPrompt when no session
2. Line 371-372: Use showToast instead of showError for API errors
3. Added 8-second duration for error messages (longer than default)

**Behavior:**
- `showError()` - Reserved for fatal initialization errors (invalid token, etc.)
- `showToast()` - Used for retryable errors (network, API failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)