### PR TITLE
FIX CRITICAL: Fix ReferenceError - intendedRole used before initializ…

### DIFF
--- a/api/accept-invite.js
+++ b/api/accept-invite.js
@@ -137,13 +137,6 @@ export default async function handler(req, res) {
       });
     }
 
-    console.log('✅ [ACCEPT-INVITE] Invite found:', {
-      id: invite.id,
-      wedding_id: invite.wedding_id,
-      is_used: invite.is_used,
-      role: intendedRole
-    });
-
     // ========================================================================
     // Extract role from token (base schema compatibility)
     // ========================================================================
@@ -162,6 +155,13 @@ export default async function handler(req, res) {
     if (invite.role) {
       intendedRole = invite.role;
     }
+
+    console.log('✅ [ACCEPT-INVITE] Invite found:', {
+      id: invite.id,
+      wedding_id: invite.wedding_id,
+      is_used: invite.is_used,
+      role: intendedRole
+    });
 
     // ONLY 3 valid roles: owner, partner, bestie
     // Use the intended role directly


### PR DESCRIPTION
…ation

**Critical JavaScript Error:**
```
ReferenceError: Cannot access 'intendedRole' before initialization
```

**Root Cause:**
In api/accept-invite.js line 144, console.log was using `intendedRole` variable, but it wasn't declared until line 153. This caused the entire API endpoint to crash.

**The Bug:**
```javascript
// ❌ BROKEN - using before declaring:
console.log('Invite found:', { role: intendedRole });  // line 144
let intendedRole = 'partner';  // line 153 - TOO LATE!
```

**The Fix:**
```javascript
// ✅ FIXED - declare first, then use:
let intendedRole = 'partner';  // Extract role from token
if (invite.role) {
  intendedRole = invite.role;
}
console.log('Invite found:', { role: intendedRole });  // NOW IT WORKS!
```

**What Changed:**
Moved the role extraction logic (lines 147-164) BEFORE the console.log (line 140-145) so that `intendedRole` is properly initialized before being referenced.

**Impact:**
This was causing ALL invite acceptances to fail with a 500 error because the API endpoint would crash immediately when trying to log the invite details.

**Variables Checked:**
- ✅ intendedRole - FIXED (was used before declaration)
- ✅ dbRole - OK (uses intendedRole after it's declared)
- ✅ permissions - OK (uses intendedRole after it's declared)
- ✅ finalPermissions - OK (uses permissions after it's declared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)