### PR TITLE
FIX CRITICAL: Store wedding_id in localStorage after invite acceptance

### DIFF
--- a/public/accept-invite-luxury.html
+++ b/public/accept-invite-luxury.html
@@ -383,6 +383,17 @@
                     redirect_to: result.redirect_to
                 });
 
+                // CRITICAL: Store wedding_id and role in localStorage IMMEDIATELY
+                // This ensures wedding_id is available for all subsequent navigation
+                if (result.wedding?.id) {
+                    localStorage.setItem('wedding_id', result.wedding.id);
+                    console.log('✅ [FRONTEND] Stored wedding_id in localStorage:', result.wedding.id);
+                }
+                if (result.your_role) {
+                    localStorage.setItem('user_role', result.your_role);
+                    console.log('✅ [FRONTEND] Stored user_role in localStorage:', result.your_role);
+                }
+
                 // Clear pending invite token from localStorage
                 localStorage.removeItem('pending_invite_token');
 


### PR DESCRIPTION
The wedding_id was being lost after invite acceptance because it was never stored in localStorage. This caused bestie chat and other pages to fail with "No wedding profile found" error.

Root cause:
- After successful invite acceptance, the API returns wedding.id
- Client redirects to dashboard with wedding_id in URL parameter
- BUT wedding_id was never stored in localStorage
- If user clicked any link before dashboard finished loading, wedding_id was lost

Fix:
- Store wedding_id and user_role in localStorage IMMEDIATELY after acceptance
- Added before redirect to ensure it's available for all subsequent navigation
- Added console logging to track the storage

Now the flow works:
1. Accept invite ✅
2. Store wedding_id in localStorage ✅
3. Redirect to dashboard ✅
4. Click chat link → wedding_id available ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)