### PR TITLE
FIX CRITICAL: Initialize wedding_id from URL params and localStorage …

### DIFF
--- a/public/bestie-luxury.html
+++ b/public/bestie-luxury.html
@@ -215,10 +215,29 @@
         // Initialize Supabase
         const supabase = initSupabase();
 
-        // Get wedding_id from URL
-        let weddingId = null;
-        let userRole = null;
+        // Get wedding_id from URL params or localStorage
+        const urlParams = new URLSearchParams(window.location.search);
+        let weddingId = urlParams.get('wedding_id') || localStorage.getItem('wedding_id');
+        let userRole = localStorage.getItem('user_role') || 'bestie';
         let conversationHistory = [];
+
+        // Log initialization for debugging
+        console.log('🔵 [BESTIE-CHAT] Initializing...');
+        console.log('🔵 [BESTIE-CHAT] URL wedding_id:', urlParams.get('wedding_id'));
+        console.log('🔵 [BESTIE-CHAT] localStorage wedding_id:', localStorage.getItem('wedding_id'));
+        console.log('🔵 [BESTIE-CHAT] Final wedding_id:', weddingId);
+
+        // If no wedding_id, redirect to dashboard
+        if (!weddingId) {
+            console.error('❌ [BESTIE-CHAT] No wedding_id found - redirecting to dashboard');
+            showToast('No wedding found. Please navigate from your dashboard.', 'error');
+            setTimeout(() => {
+                window.location.href = '/bestie-dashboard-luxury.html';
+            }, 2000);
+            throw new Error('No wedding_id available');
+        }
+
+        console.log('✅ [BESTIE-CHAT] Bestie chat loaded with wedding_id:', weddingId);
 
         // Make functions globally available
         window.goBack = function() {


### PR DESCRIPTION
…in bestie chat

The bestie chat was failing because wedding_id was initialized as null and never properly set before being used in API calls.

Root cause:
- Line 219 had: let weddingId = null;
- initializeBestie() tried to load data without a wedding_id
- API calls failed with "No wedding profile found"

Fix:
- Initialize weddingId from URL params FIRST
- Fall back to localStorage if URL param missing
- Redirect to dashboard if no wedding_id found
- Added extensive logging to track wedding_id source
- Error handling with user-friendly messages

Now the flow works:
1. Check URL params for wedding_id ✅
2. Fall back to localStorage ✅
3. If still null, redirect to dashboard ✅
4. Log all steps for debugging ✅

Navigation verified:
- All bestie chat links have IDs
- All links included in navLinks array
- wedding_id properly passed in URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)