### PR TITLE
Make onboarding optional with “Skip onboarding” fallback

### DIFF
--- a/public/onboarding-luxury.html
+++ b/public/onboarding-luxury.html
@@ -259,6 +259,16 @@
                 </div>
             </div>
 
+            <div class="skip-container" style="text-align:center;margin-top:20px;">
+                <button id="skipOnboarding" class="btn btn-outline" 
+                        style="border-color:var(--color-gold);color:var(--color-gold);">
+                    Skip onboarding for now →
+                </button>
+                <p style="font-size:0.9rem;color:var(--color-muted);margin-top:8px;">
+                    You can finish setup anytime from your Dashboard.
+                </p>
+            </div>
+
             <!-- Toast Container -->
             <div id="toastContainer" class="toast-container"></div>
 
@@ -739,6 +749,36 @@
                 }
             });
         });
+
+        // --- Skip Onboarding Logic ---
+        const skipBtn = document.getElementById('skipOnboarding');
+        if (skipBtn) {
+            skipBtn.addEventListener('click', async () => {
+                try {
+                    const { data: { user } } = await supabase.auth.getUser();
+                    if (!user) {
+                        showToast('You must be logged in first.', 'error');
+                        window.location.href = 'login-luxury.html';
+                        return;
+                    }
+
+                    const userId = localStorage.getItem('user_id') || user.id;
+                    const weddingId = localStorage.getItem('wedding_id');
+                    if (!userId) {
+                        localStorage.setItem('user_id', user.id);
+                    }
+                    if (!weddingId) console.warn('No wedding_id found, continuing to dashboard.');
+
+                    showToast('Onboarding skipped. Redirecting you to your dashboard...', 'info', 4000);
+                    setTimeout(() => {
+                        window.location.href = 'dashboard-luxury.html';
+                    }, 1200);
+                } catch (err) {
+                    console.error('Error skipping onboarding:', err);
+                    showToast('Something went wrong. Try again.', 'error', 4000);
+                }
+            });
+        }
     </script>
 
     <!-- Custom Styles -->

--- a/public/signup-luxury.html
+++ b/public/signup-luxury.html
@@ -120,6 +120,14 @@
                         </label>
                     </div>
 
+                    <div class="form-group">
+                        <label class="form-label">Have you already started planning?</label>
+                        <div>
+                            <label><input type="radio" name="startedPlanning" value="true"> Yes</label>
+                            <label style="margin-left: var(--space-4);"><input type="radio" name="startedPlanning" value="false" checked> Not yet</label>
+                        </div>
+                    </div>
+
                     <!-- Submit Button -->
                     <button type="submit" class="btn btn-primary btn-lg btn-full">
                         <svg style="width: 20px; height: 20px; fill: currentColor;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
@@ -294,6 +302,8 @@
 
                 // Determine redirect URL based on context
                 let redirectUrl;
+                const startedPlanning =
+                    document.querySelector('input[name="startedPlanning"]:checked')?.value === 'true';
                 if (inviteToken) {
                     // User came from invite - return to accept-invite page
                     // Set flag to auto-accept the invite
@@ -305,10 +315,12 @@
                     // Custom return URL provided
                     redirectUrl = returnTo;
                     showToast('success', 'Account Created!', 'Redirecting...');
-                } else {
-                    // New wedding owner - send to onboarding
+                } else if (startedPlanning) {
                     redirectUrl = 'onboarding-luxury.html';
-                    showToast('success', 'Account Created!', 'Redirecting to onboarding...');
+                    showToast('success', 'Account Created!', 'Redirecting you to onboarding...');
+                } else {
+                    redirectUrl = 'dashboard-luxury.html';
+                    showToast('success', 'Account Created!', 'Redirecting you to your dashboard...');
                 }
 
                 // Redirect after a short delay


### PR DESCRIPTION
Adds a planning question to signup-luxury.html.
Redirects “Yes” responses to onboarding-luxury.html, others to dashboard-luxury.html.
Adds “Skip Onboarding” button for mid-flow exits.
Updates toast messages to match destination.
Keeps Supabase auth and wedding_id persistence stable.
Enhances UX for both new and experienced planners.

------
https://chatgpt.com/codex/tasks/task_b_690371fa90d883209ac93f5f049c9a16