### PR TITLE
Add automatic trial loading screen and remove redundant free trial button

### DIFF
--- a/public/signup-luxury.html
+++ b/public/signup-luxury.html
@@ -149,11 +149,21 @@
         </div>
     </div>
 
+    <!-- Trial Loading Overlay -->
+    <div id="trialLoadingOverlay" class="trial-loading-overlay" aria-hidden="true">
+        <div class="overlay-content">
+            <div class="overlay-spinner" role="status" aria-live="polite"></div>
+            <p class="overlay-text overlay-text-primary">✨ Starting your 7-day free trial…</p>
+            <p class="overlay-text overlay-text-secondary">Upgrade anytime from your dashboard.</p>
+        </div>
+    </div>
+
     <!-- Scripts -->
     <script type="module">
         import { initSupabase } from '/js/shared.js';
 
         const supabase = initSupabase();
+        const trialLoadingOverlay = document.getElementById('trialLoadingOverlay');
 
         // Check for invite token or return URL in query params
         const urlParams = new URLSearchParams(window.location.search);
@@ -212,6 +222,18 @@
         // Clear Alert
         function clearAlert() {
             document.getElementById('alertContainer').innerHTML = '';
+        }
+
+        function showTrialLoadingOverlay() {
+            if (!trialLoadingOverlay) return;
+            trialLoadingOverlay.classList.add('is-active');
+            trialLoadingOverlay.setAttribute('aria-hidden', 'false');
+        }
+
+        function hideTrialLoadingOverlay() {
+            if (!trialLoadingOverlay) return;
+            trialLoadingOverlay.classList.remove('is-active');
+            trialLoadingOverlay.setAttribute('aria-hidden', 'true');
         }
 
         // Form Validation
@@ -323,16 +345,21 @@
                     showToast('success', 'Account Created!', 'Redirecting you to your dashboard...');
                 }
 
-                // Redirect after a short delay
+                // Show trial confirmation overlay before redirecting
+                showTrialLoadingOverlay();
+
+                const overlayDuration = 2400;
+
                 setTimeout(() => {
                     window.location.href = redirectUrl;
-                }, 1500);
+                }, overlayDuration);
 
             } catch (error) {
                 console.error('Signup error:', error);
                 showAlert('error', 'Signup Failed', error.message || 'An error occurred during signup. Please try again.');
                 btn.classList.remove('btn-loading');
                 btn.disabled = false;
+                hideTrialLoadingOverlay();
             }
         });
 
@@ -387,6 +414,63 @@
         /* Checkbox styling */
         .checkbox-label a:hover {
             color: var(--color-gold);
+        }
+
+        .trial-loading-overlay {
+            position: fixed;
+            inset: 0;
+            display: none;
+            align-items: center;
+            justify-content: center;
+            background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
+            background-color: var(--color-navy);
+            backdrop-filter: blur(6px);
+            z-index: 999;
+            padding: var(--space-8);
+        }
+
+        .trial-loading-overlay.is-active {
+            display: flex;
+        }
+
+        .trial-loading-overlay .overlay-content {
+            text-align: center;
+            max-width: 420px;
+        }
+
+        .overlay-spinner {
+            width: 72px;
+            height: 72px;
+            border-radius: 50%;
+            border: 4px solid rgba(255, 255, 255, 0.2);
+            border-top-color: var(--color-gold);
+            border-right-color: var(--color-sunset);
+            margin: 0 auto var(--space-6);
+            animation: overlay-spin 0.9s linear infinite;
+        }
+
+        .overlay-text {
+            font-family: var(--font-heading);
+            color: var(--color-gold);
+            margin-bottom: var(--space-2);
+        }
+
+        .overlay-text-primary {
+            font-size: var(--text-xl);
+            color: var(--color-gold);
+        }
+
+        .overlay-text-secondary {
+            font-family: var(--font-body);
+            font-size: var(--text-base);
+            color: var(--color-sunset);
+            margin-bottom: 0;
+        }
+
+        @keyframes overlay-spin {
+            to {
+                transform: rotate(360deg);
+            }
         }
     </style>
 </body>

--- a/public/subscribe-luxury.html
+++ b/public/subscribe-luxury.html
@@ -34,8 +34,8 @@
                 <h2 style="font-family: var(--font-heading); font-size: var(--text-3xl); color: var(--color-heading); margin-bottom: var(--space-2);">
                     Choose Your Plan
                 </h2>
-                <p style="color: var(--color-body); opacity: 0.9; font-size: var(--text-lg);">
-                    Start your 7-day free trial. No credit card required!
+                <p style="color: var(--color-body); opacity: 0.9; font-size: var(--text-lg); max-width: 560px; margin: 0 auto;">
+                    Your 7-day VIP trial has already started. You can upgrade anytime below.
                 </p>
             </div>
 
@@ -90,10 +90,10 @@
                     </ul>
 
                     <button class="btn btn-primary btn-full btn-lg" style="margin-bottom: var(--space-3);" onclick="selectPlan('vip', 'monthly')">
-                        Start Free Trial
+                        Upgrade – Monthly Subscription
                     </button>
                     <button class="btn btn-secondary btn-full" onclick="selectPlan('vip', 'one_time')">
-                        One-Time Payment
+                        Upgrade – One-Time Payment
                     </button>
                 </div>
 
@@ -149,10 +149,10 @@
                     </ul>
 
                     <button class="btn btn-primary btn-full btn-lg" style="margin-bottom: var(--space-3);" onclick="selectPlan('vip_bestie', 'monthly')">
-                        Start Free Trial
+                        Upgrade – Monthly Subscription
                     </button>
                     <button class="btn btn-secondary btn-full" onclick="selectPlan('vip_bestie', 'one_time')">
-                        One-Time Payment
+                        Upgrade – One-Time Payment
                     </button>
                 </div>
 
@@ -200,32 +200,7 @@
         // Make function globally available
         window.selectPlan = async function(tier, billing) {
             try {
-                // If "monthly" (Start Free Trial), enable the plan and go to dashboard
-                if (billing === 'monthly') {
-                    // Enable bestie addon if VIP+Bestie plan selected
-                    if (tier === 'vip_bestie') {
-                        const { data: { session } } = await supabase.auth.getSession();
-                        if (session) {
-                            // Enable bestie addon for trial
-                            const { error } = await supabase
-                                .from('wedding_profiles')
-                                .update({ bestie_addon_enabled: true })
-                                .eq('id', weddingId);
-
-                            if (error) {
-                                console.error('Error enabling bestie addon:', error);
-                                showToast('Trial started, but bestie addon could not be enabled. Please contact support.', 'warning');
-                            } else {
-                                showToast('VIP+Bestie trial started! Bestie features enabled.', 'success');
-                            }
-                        }
-                    }
-
-                    window.location.href = `dashboard-luxury.html?wedding_id=${weddingId}`;
-                    return;
-                }
-
-                // For one-time payment, go through Stripe checkout
+                // All upgrade options go through Stripe checkout
                 // SECURITY: Get session token to pass to server for verification
                 const { data: { session } } = await supabase.auth.getSession();
                 if (!session) {


### PR DESCRIPTION
## Summary
- remove the redundant "Start Free Trial" call-to-action on the luxury subscribe page now that accounts receive a trial automatically
- update the pricing cards to focus on paid upgrade actions that funnel through Stripe checkout
- add a branded post-signup loading overlay that confirms the 7-day trial has started before routing users to their dashboard or onboarding

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_690395942df083208ae1347a307d46a3