### PR TITLE
Redirect all logins and signups to chat pages instead of dashboard

### DIFF
--- a/public/login-luxury.html
+++ b/public/login-luxury.html
@@ -276,10 +276,22 @@
                 }
 
                 // Use the first wedding (most recent)
-                const weddingId = members[0].wedding_id;
+                const primaryMember = members[0] || {};
+                const weddingId = primaryMember.wedding_id;
 
                 // Store session in localStorage immediately
                 storeUserSession(data.user.id, weddingId);
+
+                // Persist user role when available for downstream flows
+                if (primaryMember.role) {
+                    localStorage.setItem('user_role', primaryMember.role);
+                }
+                const storedUserRole = localStorage.getItem('user_role');
+                const isBestie = (primaryMember.role || storedUserRole) === 'bestie';
+                const chatDestination = isBestie ? 'bestie-chat-luxury.html' : 'chat-luxury.html';
+                const chatToastMessage = isBestie
+                    ? 'Redirecting you to bestie chat…'
+                    : 'Redirecting you to chat…';
 
                 // Determine redirect URL based on context
                 if (inviteToken) {
@@ -292,8 +304,10 @@
                     // Custom return URL provided
                     window.location.href = returnTo;
                 } else {
-                    // Normal login - redirect to dashboard
-                    window.location.href = `dashboard-luxury.html?wedding_id=${weddingId}`;
+                    // Normal login - redirect to appropriate chat experience
+                    showToast(chatToastMessage, 'success');
+                    const chatUrl = weddingId ? `${chatDestination}?wedding_id=${weddingId}` : chatDestination;
+                    window.location.href = chatUrl;
                 }
             } catch (error) {
                 console.error('Login error:', error.message);

--- a/public/signup-luxury.html
+++ b/public/signup-luxury.html
@@ -326,6 +326,8 @@
                 let redirectUrl;
                 const startedPlanning =
                     document.querySelector('input[name="startedPlanning"]:checked')?.value === 'true';
+                const storedUserRole = localStorage.getItem('user_role');
+                const isBestie = storedUserRole === 'bestie';
                 if (inviteToken) {
                     // User came from invite - return to accept-invite page
                     // Set flag to auto-accept the invite
@@ -337,12 +339,18 @@
                     // Custom return URL provided
                     redirectUrl = returnTo;
                     showToast('success', 'Account Created!', 'Redirecting...');
-                } else if (startedPlanning) {
-                    redirectUrl = 'onboarding-luxury.html';
-                    showToast('success', 'Account Created!', 'Redirecting you to onboarding...');
                 } else {
-                    redirectUrl = 'dashboard-luxury.html';
-                    showToast('success', 'Account Created!', 'Redirecting you to your dashboard...');
+                    const chatDestination = isBestie ? 'bestie-chat-luxury.html' : 'chat-luxury.html';
+                    const chatToastMessage = isBestie
+                        ? 'Redirecting you to bestie chat…'
+                        : 'Redirecting you to chat…';
+                    const searchParams = new URLSearchParams();
+                    if (startedPlanning) {
+                        searchParams.set('started_planning', 'true');
+                    }
+                    const queryString = searchParams.toString();
+                    redirectUrl = queryString ? `${chatDestination}?${queryString}` : chatDestination;
+                    showToast('success', 'Account Created!', chatToastMessage);
                 }
 
                 // Show trial confirmation overlay before redirecting


### PR DESCRIPTION
## Summary
- redirect post-login flows to send members to chat-luxury.html or bestie-chat-luxury.html based on their stored role
- update the signup flow to send new accounts straight into the appropriate chat experience while keeping invite and return logic intact
- refresh success toasts so users know they are being routed directly into chat, improving immediacy and engagement

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_690398e496f88320bd103f36e4cefad2