### PR TITLE
Make full signup form the default Start Your Wedding page

### DIFF
--- a/public/index-luxury.html
+++ b/public/index-luxury.html
@@ -48,7 +48,7 @@
 
                     <!-- CTA Buttons -->
                     <div style="display: flex; flex-direction: column; gap: var(--space-4); margin-bottom: var(--space-8); max-width: 400px; margin-left: auto; margin-right: auto;">
-                        <a href="onboarding-luxury.html" class="btn btn-primary btn-lg btn-full">
+                        <a href="signup-luxury.html" class="btn btn-primary btn-lg btn-full">
                             <svg style="width: 24px; height: 24px; fill: currentColor;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                                 <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
                             </svg>

--- a/public/login-luxury.html
+++ b/public/login-luxury.html
@@ -97,7 +97,7 @@
                     <!-- Sign Up Link -->
                     <p style="text-align: center; margin-top: var(--space-6); font-size: var(--text-sm); color: var(--color-burgundy);">
                         Don't have an account?
-                        <a href="onboarding-luxury.html" style="color: var(--color-gold); text-decoration: none; font-weight: 500;">
+                        <a href="signup-luxury.html" style="color: var(--color-gold); text-decoration: none; font-weight: 500;">
                             Start your wedding
                         </a>
                     </p>

--- a/public/onboarding-luxury.html
+++ b/public/onboarding-luxury.html
@@ -322,6 +322,12 @@
             try {
                 const { data: { session } } = await supabase.auth.getSession();
 
+                if (!session || !session.user) {
+                    console.log('ℹ️ No active session - redirecting to full signup flow');
+                    window.location.href = 'signup-luxury.html';
+                    return;
+                }
+
                 if (session && session.user) {
                     console.log('✅ Existing session found');
 

--- a/public/signup-luxury.html
+++ b/public/signup-luxury.html
@@ -339,17 +339,15 @@
                     // Custom return URL provided
                     redirectUrl = returnTo;
                     showToast('success', 'Account Created!', 'Redirecting...');
+                } else if (startedPlanning) {
+                    redirectUrl = 'onboarding-luxury.html';
+                    showToast('success', 'Account Created!', "Let's gather a few wedding details…");
                 } else {
                     const chatDestination = isBestie ? 'bestie-chat-luxury.html' : 'chat-luxury.html';
                     const chatToastMessage = isBestie
                         ? 'Redirecting you to bestie chat…'
                         : 'Redirecting you to chat…';
-                    const searchParams = new URLSearchParams();
-                    if (startedPlanning) {
-                        searchParams.set('started_planning', 'true');
-                    }
-                    const queryString = searchParams.toString();
-                    redirectUrl = queryString ? `${chatDestination}?${queryString}` : chatDestination;
+                    redirectUrl = chatDestination;
                     showToast('success', 'Account Created!', chatToastMessage);
                 }
 


### PR DESCRIPTION
## Summary
- update the Start Your Wedding calls-to-action to load the full luxury signup experience
- redirect logged-out visitors away from the simplified onboarding flow so it is reserved for authenticated setup
- align the signup redirect logic with the new flow, sending planners who have already started to the onboarding experience

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_69039c3b9e3483209cb1453280dd7a7d