### PR TITLE
Strengthen chat payload validation and add regression tests

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -1,6 +1,661 @@
 import { createClient } from '@supabase/supabase-js';
 import { handleCORS, rateLimitMiddleware, RATE_LIMITS } from './_utils/rate-limiter.js';
 
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const PHONE_REGEX = /^\+?[0-9()[\]\s-]{7,}$/;
+const CLAUDE_RESPONSE_CHAR_LIMIT = 20000;
+const MAX_EXTRACTED_JSON_CHARS = 12000;
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+function logError(message, error) {
+  if (isProduction) {
+    console.error(message);
+    return;
+  }
+
+  if (error?.message) {
+    console.error(message, { message: error.message });
+  } else if (error) {
+    console.error(message, error);
+  } else {
+    console.error(message);
+  }
+}
+
+const VENDOR_TYPE_ALIASES = new Map([
+  ['photography', 'photographer'],
+  ['photo', 'photographer'],
+  ['photos', 'photographer'],
+  ['dj/band', 'dj'],
+  ['band', 'dj'],
+  ['music', 'dj'],
+  ['bakery', 'baker'],
+  ['cake', 'baker'],
+  ['cakes', 'baker'],
+  ['makeup', 'hair_makeup'],
+  ['hair & makeup', 'hair_makeup'],
+  ['hair and makeup', 'hair_makeup'],
+  ['transport', 'transportation'],
+  ['planner/coordinator', 'planner'],
+  ['coordinator', 'planner'],
+  ['decor', 'decorator'],
+  ['lighting', 'decorator']
+]);
+
+const VENDOR_TYPES = new Set([
+  'photographer',
+  'caterer',
+  'florist',
+  'dj',
+  'videographer',
+  'baker',
+  'planner',
+  'venue',
+  'decorator',
+  'hair_makeup',
+  'transportation',
+  'rentals',
+  'other'
+]);
+
+const VENDOR_STATUSES = new Set([
+  'inquiry',
+  'pending',
+  'booked',
+  'contract_signed',
+  'deposit_paid',
+  'fully_paid',
+  'rejected',
+  'cancelled'
+]);
+
+const BUDGET_CATEGORIES = new Map([
+  ['venue', 'venue'],
+  ['ceremony', 'venue'],
+  ['reception', 'venue'],
+  ['catering', 'catering'],
+  ['food', 'catering'],
+  ['flowers', 'flowers'],
+  ['floral', 'flowers'],
+  ['photography', 'photography'],
+  ['photo', 'photography'],
+  ['videography', 'videography'],
+  ['music', 'music'],
+  ['dj', 'music'],
+  ['band', 'music'],
+  ['cake', 'cake'],
+  ['dessert', 'cake'],
+  ['decor', 'decorations'],
+  ['decorations', 'decorations'],
+  ['attire', 'attire'],
+  ['dress', 'attire'],
+  ['suit', 'attire'],
+  ['invitations', 'invitations'],
+  ['stationery', 'invitations'],
+  ['favors', 'favors'],
+  ['transport', 'transportation'],
+  ['transportation', 'transportation'],
+  ['honeymoon', 'honeymoon'],
+  ['other', 'other']
+]);
+
+const TASK_CATEGORIES = new Map([
+  ['venue', 'venue'],
+  ['catering', 'catering'],
+  ['flowers', 'flowers'],
+  ['floral', 'flowers'],
+  ['photography', 'photography'],
+  ['photo', 'photography'],
+  ['attire', 'attire'],
+  ['dress', 'attire'],
+  ['invitations', 'invitations'],
+  ['decor', 'decorations'],
+  ['decorations', 'decorations'],
+  ['transport', 'transportation'],
+  ['transportation', 'transportation'],
+  ['legal', 'legal'],
+  ['honeymoon', 'honeymoon'],
+  ['day_of', 'day_of'],
+  ['day-of', 'day_of'],
+  ['other', 'other']
+]);
+
+const TASK_STATUSES = new Set(['not_started', 'in_progress', 'completed', 'cancelled']);
+const TASK_PRIORITIES = new Set(['low', 'medium', 'high', 'urgent']);
+
+function vendorKey(type, name) {
+  return `${type}:${name.toLowerCase()}`;
+}
+
+function taskDeterministicId(name, dueDate) {
+  return `${name.toLowerCase()}::${dueDate || 'none'}`;
+}
+
+function toTrimmedString(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function normalizeDate(value) {
+  if (!value) return null;
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (!DATE_REGEX.test(trimmed)) return null;
+  const date = new Date(trimmed);
+  if (Number.isNaN(date.getTime())) return null;
+  const [year, month, day] = trimmed.split('-');
+  if (date.getUTCFullYear() !== Number(year) || date.getUTCMonth() + 1 !== Number(month) || date.getUTCDate() !== Number(day)) {
+    return null;
+  }
+  return `${year.padStart(4, '0')}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
+}
+
+function normalizeCurrency(value) {
+  if (value === null || value === undefined || value === '') return null;
+  if (typeof value === 'number') {
+    return Number.isFinite(value) && value >= 0 ? Math.round(value) : null;
+  }
+
+  if (typeof value !== 'string') return null;
+  const cleaned = value.replace(/[^0-9.-]/g, '');
+  if (!cleaned) return null;
+  const parsed = Number.parseFloat(cleaned);
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
+  return Math.round(parsed);
+}
+
+function normalizeInteger(value) {
+  if (value === null || value === undefined || value === '') return null;
+  if (typeof value === 'number') {
+    return Number.isInteger(value) && value >= 0 ? value : null;
+  }
+  if (typeof value !== 'string') return null;
+  const cleaned = value.replace(/[^0-9]/g, '');
+  if (!cleaned) return null;
+  const parsed = Number.parseInt(cleaned, 10);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function normalizeBoolean(value) {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'boolean') return value;
+  if (typeof value !== 'string') return null;
+  const lowered = value.trim().toLowerCase();
+  if (!lowered) return null;
+  if (['true', 'yes', 'y', 'paid', 'completed'].includes(lowered)) return true;
+  if (['false', 'no', 'n', 'unpaid', 'not paid'].includes(lowered)) return false;
+  return null;
+}
+
+function canonicalizeVendorType(value) {
+  if (!value) return null;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return null;
+  if (VENDOR_TYPES.has(normalized)) return normalized;
+  return VENDOR_TYPE_ALIASES.get(normalized) || null;
+}
+
+function canonicalizeBudgetCategory(value) {
+  if (!value) return null;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return null;
+  return BUDGET_CATEGORIES.get(normalized) || null;
+}
+
+function canonicalizeTaskCategory(value) {
+  if (!value) return null;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return null;
+  return TASK_CATEGORIES.get(normalized) || null;
+}
+
+function validateEmail(value) {
+  const str = toTrimmedString(value);
+  if (!str) return null;
+  return EMAIL_REGEX.test(str) ? str : null;
+}
+
+function validatePhone(value) {
+  const str = toTrimmedString(value);
+  if (!str) return null;
+  return PHONE_REGEX.test(str) ? str : null;
+}
+
+function sanitizeWeddingInfo(weddingInfo) {
+  if (!weddingInfo || typeof weddingInfo !== 'object') {
+    return { sanitized: {}, warnings: [] };
+  }
+
+  const sanitized = {};
+  const warnings = [];
+
+  for (const [key, value] of Object.entries(weddingInfo)) {
+    if (value === null || value === undefined || value === '') {
+      continue;
+    }
+
+    switch (key) {
+      case 'wedding_date': {
+        const normalized = normalizeDate(value);
+        if (normalized) {
+          sanitized.wedding_date = normalized;
+        } else {
+          warnings.push(`Ignored wedding_date: expected YYYY-MM-DD, received "${value}".`);
+        }
+        break;
+      }
+      case 'wedding_time': {
+        const formatted = formatWeddingTimeForSupabase(value);
+        if (formatted) {
+          sanitized.wedding_time = formatted;
+        } else {
+          warnings.push(`Ignored wedding_time: unrecognized time "${value}".`);
+        }
+        break;
+      }
+      case 'expected_guest_count': {
+        const count = normalizeInteger(value);
+        if (count !== null) {
+          sanitized.expected_guest_count = count;
+        } else {
+          warnings.push(`Ignored expected_guest_count: expected whole number, received "${value}".`);
+        }
+        break;
+      }
+      case 'total_budget': {
+        const budget = normalizeCurrency(value);
+        if (budget !== null) {
+          sanitized.total_budget = budget;
+        } else {
+          warnings.push(`Ignored total_budget: expected positive currency, received "${value}".`);
+        }
+        break;
+      }
+      case 'venue_cost': {
+        const cost = normalizeCurrency(value);
+        if (cost !== null) {
+          sanitized.venue_cost = cost;
+        } else {
+          warnings.push(`Ignored venue_cost: expected positive currency, received "${value}".`);
+        }
+        break;
+      }
+      case 'partner1_name':
+      case 'partner2_name':
+      case 'ceremony_location':
+      case 'reception_location':
+      case 'venue_name':
+      case 'color_scheme_primary':
+      case 'color_scheme_secondary':
+      case 'wedding_style':
+      case 'wedding_name': {
+        const str = toTrimmedString(value);
+        if (str) {
+          sanitized[key] = str;
+        }
+        break;
+      }
+      default: {
+        // Ignore unexpected keys silently to avoid storing arbitrary data
+        break;
+      }
+    }
+  }
+
+  return { sanitized, warnings };
+}
+
+function sanitizeVendors(vendors) {
+  if (!Array.isArray(vendors) || vendors.length === 0) {
+    return { sanitized: [], warnings: [] };
+  }
+
+  const sanitized = [];
+  const warnings = [];
+  const seen = new Set();
+
+  vendors.forEach((vendor, index) => {
+    if (!vendor || typeof vendor !== 'object') {
+      warnings.push(`Skipped vendor at index ${index}: expected object.`);
+      return;
+    }
+
+    const vendorName = toTrimmedString(vendor.vendor_name);
+    const vendorType = canonicalizeVendorType(vendor.vendor_type);
+
+    if (!vendorName) {
+      warnings.push(`Skipped vendor at index ${index}: missing vendor_name.`);
+      return;
+    }
+
+    if (!vendorType) {
+      warnings.push(`Skipped vendor "${vendorName}": unsupported vendor_type "${vendor.vendor_type}".`);
+      return;
+    }
+
+    const key = vendorKey(vendorType, vendorName);
+    if (seen.has(key)) {
+      warnings.push(`Skipped vendor "${vendorName}" (${vendorType}): duplicate entry.`);
+      return;
+    }
+    seen.add(key);
+
+    const totalCost = normalizeCurrency(vendor.total_cost);
+    const depositAmount = normalizeCurrency(vendor.deposit_amount);
+    const balanceDue = normalizeCurrency(vendor.balance_due);
+
+    let adjustedDeposit = depositAmount;
+    if (totalCost !== null && depositAmount !== null && depositAmount > totalCost) {
+      adjustedDeposit = totalCost;
+      warnings.push(`Adjusted deposit for vendor "${vendorName}" to not exceed total_cost.`);
+    }
+
+    const status = vendor.status ? vendor.status.trim().toLowerCase() : null;
+    const canonicalStatus = status && VENDOR_STATUSES.has(status) ? status : null;
+    if (status && !canonicalStatus) {
+      warnings.push(`Dropped unsupported status "${vendor.status}" for vendor "${vendorName}".`);
+    }
+
+    const sanitizedVendor = {
+      vendor_type: vendorType,
+      vendor_name: vendorName,
+      vendor_contact_name: toTrimmedString(vendor.vendor_contact_name),
+      vendor_email: validateEmail(vendor.vendor_email),
+      vendor_phone: validatePhone(vendor.vendor_phone),
+      total_cost: totalCost,
+      deposit_amount: adjustedDeposit,
+      deposit_paid: normalizeBoolean(vendor.deposit_paid),
+      deposit_date: normalizeDate(vendor.deposit_date),
+      balance_due: balanceDue,
+      final_payment_date: normalizeDate(vendor.final_payment_date),
+      final_payment_paid: normalizeBoolean(vendor.final_payment_paid),
+      status: canonicalStatus,
+      contract_signed: normalizeBoolean(vendor.contract_signed),
+      contract_date: normalizeDate(vendor.contract_date),
+      service_date: normalizeDate(vendor.service_date),
+      notes: toTrimmedString(vendor.notes)
+    };
+
+    const hasMeaningfulData =
+      sanitizedVendor.total_cost !== null ||
+      sanitizedVendor.deposit_amount !== null ||
+      sanitizedVendor.status !== null ||
+      sanitizedVendor.notes ||
+      sanitizedVendor.deposit_paid !== null ||
+      sanitizedVendor.contract_signed !== null ||
+      sanitizedVendor.balance_due !== null;
+
+    if (!hasMeaningfulData) {
+      warnings.push(`Skipped vendor "${vendorName}" (${vendorType}): no actionable data provided.`);
+      return;
+    }
+
+    sanitized.push(sanitizedVendor);
+  });
+
+  return { sanitized, warnings };
+}
+
+function sanitizeBudgetItems(budgetItems) {
+  if (!Array.isArray(budgetItems) || budgetItems.length === 0) {
+    return { sanitized: [], warnings: [] };
+  }
+
+  const aggregated = new Map();
+  const warnings = [];
+
+  budgetItems.forEach((item, index) => {
+    if (!item || typeof item !== 'object') {
+      warnings.push(`Skipped budget item at index ${index}: expected object.`);
+      return;
+    }
+
+    const category = canonicalizeBudgetCategory(item.category);
+    if (!category) {
+      warnings.push(`Skipped budget item at index ${index}: unsupported category "${item.category}".`);
+      return;
+    }
+
+    const budgetedAmount = normalizeCurrency(item.budgeted_amount);
+    const spentAmount = normalizeCurrency(item.spent_amount);
+    const transactionAmount = normalizeCurrency(item.transaction_amount);
+    const transactionDate = normalizeDate(item.transaction_date);
+
+    if (budgetedAmount === null && spentAmount === null && transactionAmount === null) {
+      warnings.push(`Skipped budget item for category "${category}": no monetary values provided.`);
+      return;
+    }
+
+    const existing = aggregated.get(category) || {
+      category,
+      budgeted_amount: null,
+      spent_amount: null,
+      transaction_date: null,
+      transaction_amount: null,
+      transaction_description: null,
+      notes: null
+    };
+
+    if (budgetedAmount !== null) {
+      existing.budgeted_amount = budgetedAmount;
+    }
+
+    if (spentAmount !== null) {
+      existing.spent_amount = (existing.spent_amount || 0) + spentAmount;
+    }
+
+    if (transactionAmount !== null) {
+      existing.transaction_amount = transactionAmount;
+    }
+
+    if (transactionDate) {
+      existing.transaction_date = transactionDate;
+    }
+
+    const description = toTrimmedString(item.transaction_description);
+    if (description) {
+      existing.transaction_description = description;
+    }
+
+    const notes = toTrimmedString(item.notes);
+    if (notes) {
+      existing.notes = notes;
+    }
+
+    if (aggregated.has(category)) {
+      warnings.push(`Merged duplicate budget category "${category}".`);
+    }
+
+    aggregated.set(category, existing);
+  });
+
+  return { sanitized: Array.from(aggregated.values()), warnings };
+}
+
+function sanitizeTasks(tasks) {
+  if (!Array.isArray(tasks) || tasks.length === 0) {
+    return { sanitized: [], warnings: [] };
+  }
+
+  const sanitized = [];
+  const warnings = [];
+  const seen = new Set();
+
+  tasks.forEach((task, index) => {
+    if (!task || typeof task !== 'object') {
+      warnings.push(`Skipped task at index ${index}: expected object.`);
+      return;
+    }
+
+    const name = toTrimmedString(task.task_name);
+    if (!name) {
+      warnings.push(`Skipped task at index ${index}: missing task_name.`);
+      return;
+    }
+
+    const dueDate = normalizeDate(task.due_date);
+    if (task.due_date && !dueDate) {
+      warnings.push(`Removed invalid due_date for task "${name}".`);
+    }
+
+    const category = canonicalizeTaskCategory(task.category) || null;
+    if (task.category && !category) {
+      warnings.push(`Dropped unsupported task category "${task.category}" for "${name}".`);
+    }
+
+    const status = task.status ? task.status.trim().toLowerCase() : null;
+    const canonicalStatus = status && TASK_STATUSES.has(status) ? status : null;
+    if (status && !canonicalStatus) {
+      warnings.push(`Dropped unsupported task status "${task.status}" for "${name}".`);
+    }
+
+    const priority = task.priority ? task.priority.trim().toLowerCase() : null;
+    const canonicalPriority = priority && TASK_PRIORITIES.has(priority) ? priority : null;
+    if (priority && !canonicalPriority) {
+      warnings.push(`Dropped unsupported task priority "${task.priority}" for "${name}".`);
+    }
+
+    const slug = taskDeterministicId(name, dueDate);
+    if (seen.has(slug)) {
+      warnings.push(`Skipped duplicate task "${name}" with due date ${dueDate || 'unspecified'}.`);
+      return;
+    }
+    seen.add(slug);
+
+    sanitized.push({
+      task_name: name,
+      task_description: toTrimmedString(task.task_description),
+      category,
+      due_date: dueDate,
+      status: canonicalStatus,
+      priority: canonicalPriority,
+      notes: toTrimmedString(task.notes)
+    });
+  });
+
+  return { sanitized, warnings };
+}
+
+function formatWeddingTimeForSupabase(rawTime) {
+  if (!rawTime || typeof rawTime !== 'string') {
+    return null;
+  }
+
+  const trimmed = rawTime.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const lower = trimmed.toLowerCase();
+
+  if (lower === 'noon') {
+    return '12:00';
+  }
+
+  if (lower === 'midnight') {
+    return '00:00';
+  }
+
+  const directMatch = lower.match(/^([01]?\d|2[0-3]):([0-5]\d)(?::([0-5]\d))?$/);
+  if (directMatch) {
+    const hours = directMatch[1].padStart(2, '0');
+    const minutes = directMatch[2];
+    return `${hours}:${minutes}`;
+  }
+
+  const ampmMatch = lower.match(/(\d{1,2})(?::(\d{2}))?\s*(am|pm)/);
+  if (ampmMatch) {
+    let hours = parseInt(ampmMatch[1], 10);
+    const minutes = ampmMatch[2] ? parseInt(ampmMatch[2], 10) : 0;
+    const modifier = ampmMatch[3];
+
+    if (hours === 12) {
+      hours = modifier === 'am' ? 0 : 12;
+    } else if (modifier === 'pm') {
+      hours += 12;
+    }
+
+    return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
+  }
+
+  const embedded24HourMatch = lower.match(/\b([01]?\d|2[0-3])(:([0-5]\d))\b/);
+  if (embedded24HourMatch) {
+    const hours = embedded24HourMatch[1].padStart(2, '0');
+    const minutes = embedded24HourMatch[3];
+    return `${hours}:${minutes}`;
+  }
+
+  const embeddedHourMatch = lower.match(/\b([1-9]|1[0-2])\b/);
+  if (embeddedHourMatch) {
+    const hourVal = parseInt(embeddedHourMatch[1], 10);
+    if (hourVal >= 0 && hourVal <= 23) {
+      return `${hourVal.toString().padStart(2, '0')}:00`;
+    }
+  }
+
+  return null;
+}
+
+function processClaudePayload(rawExtractedDataText) {
+  const result = {
+    weddingInfo: {},
+    vendors: [],
+    budgetItems: [],
+    tasks: [],
+    warnings: [],
+    parseError: null
+  };
+
+  if (!rawExtractedDataText || typeof rawExtractedDataText !== 'string') {
+    return result;
+  }
+
+  const trimmed = rawExtractedDataText.trim();
+  if (!trimmed) {
+    return result;
+  }
+
+  if (trimmed.length > MAX_EXTRACTED_JSON_CHARS) {
+    result.warnings.push('I received a very large set of details, so I skipped saving them to keep things stable.');
+    return result;
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (error) {
+    result.parseError = error;
+    result.warnings.push('I could not read the structured details this time, so I did not save any changes. Could you share them again?');
+    return result;
+  }
+
+  const { sanitized: sanitizedWeddingInfo, warnings: weddingInfoWarnings } = sanitizeWeddingInfo(parsed.wedding_info);
+  const { sanitized: sanitizedVendors, warnings: vendorWarnings } = sanitizeVendors(parsed.vendors);
+  const { sanitized: sanitizedBudgetItems, warnings: budgetWarnings } = sanitizeBudgetItems(parsed.budget_items);
+  const { sanitized: sanitizedTasks, warnings: taskWarnings } = sanitizeTasks(parsed.tasks);
+
+  result.weddingInfo = sanitizedWeddingInfo;
+  result.vendors = sanitizedVendors;
+  result.budgetItems = sanitizedBudgetItems;
+  result.tasks = sanitizedTasks;
+  result.warnings.push(
+    ...weddingInfoWarnings,
+    ...vendorWarnings,
+    ...budgetWarnings,
+    ...taskWarnings
+  );
+
+  return result;
+}
+
+export { processClaudePayload, MAX_EXTRACTED_JSON_CHARS };
+
 export default async function handler(req, res) {
   // Handle CORS preflight
   if (handleCORS(req, res)) {
@@ -237,8 +892,9 @@ IMPORTANT:
     // Check if API call was successful
     if (!claudeResponse.ok) {
       const errorData = await claudeResponse.json();
-      console.error('Anthropic API error:', errorData);
-      throw new Error(`Anthropic API error: ${errorData.error?.message || 'Unknown error'}`);
+      const errorMessage = errorData?.error?.message || 'Unknown error';
+      logError('Anthropic API error', new Error(errorMessage));
+      throw new Error(`Anthropic API error: ${errorMessage}`);
     }
 
     const claudeData = await claudeResponse.json();
@@ -254,53 +910,54 @@ IMPORTANT:
     const dataMatch = fullResponse.match(/<extracted_data>([\s\S]*?)<\/extracted_data>/);
 
     let assistantMessage = responseMatch ? responseMatch[1].trim() : fullResponse;
-    let extractedData = { wedding_info: {}, vendors: [], budget_items: [], tasks: [] };
+    let processedPayload = processClaudePayload(null);
 
     if (dataMatch) {
-      try {
-        const jsonStr = dataMatch[1].trim();
-        extractedData = JSON.parse(jsonStr);
-      } catch (e) {
-        console.error('Failed to parse extracted data:', e);
+      const rawExtractedSection = dataMatch[1];
+      processedPayload = processClaudePayload(rawExtractedSection);
+      if (processedPayload.parseError) {
+        logError('Failed to parse extracted data', processedPayload.parseError);
       }
+    }
+
+    const validationNotes = [...processedPayload.warnings];
+
+    if (assistantMessage.length > CLAUDE_RESPONSE_CHAR_LIMIT) {
+      assistantMessage = `${assistantMessage.slice(0, CLAUDE_RESPONSE_CHAR_LIMIT)}…`;
+      validationNotes.push('I shortened my reply slightly to keep things running smoothly.');
     }
 
     // Update database with extracted data (FULL extraction restored)
 
     // 1. Update wedding_profiles with general wedding info
-    if (extractedData.wedding_info && Object.keys(extractedData.wedding_info).length > 0) {
-      const weddingUpdates = {};
+    if (processedPayload.weddingInfo && Object.keys(processedPayload.weddingInfo).length > 0) {
+      const { error: updateError } = await supabaseService
+        .from('wedding_profiles')
+        .update(processedPayload.weddingInfo)
+        .eq('id', membership.wedding_id);
 
-      Object.keys(extractedData.wedding_info).forEach(key => {
-        if (extractedData.wedding_info[key] !== null && extractedData.wedding_info[key] !== undefined) {
-          weddingUpdates[key] = extractedData.wedding_info[key];
-        }
-      });
-
-      if (Object.keys(weddingUpdates).length > 0) {
-        const { error: updateError } = await supabaseService
-          .from('wedding_profiles')
-          .update(weddingUpdates)
-          .eq('id', membership.wedding_id);
-
-        if (updateError) {
-          console.error('Failed to update wedding profile:', updateError);
-        }
+      if (updateError) {
+        logError('Failed to update wedding profile', updateError);
+        validationNotes.push('I had trouble saving your wedding profile details. Please try again in a moment.');
       }
     }
 
     // 2. Insert/Update vendors in vendor_tracker table (BATCHED)
-    if (extractedData.vendors && extractedData.vendors.length > 0) {
+    if (processedPayload.vendors.length > 0) {
       // Fetch all existing vendors for this wedding in one query
-      const { data: existingVendors } = await supabaseService
+      const { data: existingVendors, error: existingVendorsError } = await supabaseService
         .from('vendor_tracker')
         .select('id, vendor_type, vendor_name')
         .eq('wedding_id', membership.wedding_id);
 
       const existingVendorMap = new Map();
-      if (existingVendors) {
+      if (existingVendorsError) {
+        logError('Failed to load existing vendors', existingVendorsError);
+        validationNotes.push('I could not check your existing vendors, so I skipped vendor updates this round.');
+      } else if (existingVendors) {
         existingVendors.forEach(v => {
-          const key = `${v.vendor_type}:${(v.vendor_name || '').toLowerCase()}`;
+          if (!v.vendor_type || !v.vendor_name) return;
+          const key = vendorKey(v.vendor_type, v.vendor_name);
           existingVendorMap.set(key, v.id);
         });
       }
@@ -308,62 +965,71 @@ IMPORTANT:
       const vendorsToInsert = [];
       const vendorsToUpdate = [];
 
-      for (const vendor of extractedData.vendors) {
-        const key = `${vendor.vendor_type}:${(vendor.vendor_name || '').toLowerCase()}`;
-        const existingId = existingVendorMap.get(key);
+      if (!existingVendorsError) {
+        for (const vendor of processedPayload.vendors) {
+          const key = vendorKey(vendor.vendor_type, vendor.vendor_name);
+          const existingId = existingVendorMap.get(key);
 
-        if (existingId) {
-          // Prepare for batch update
-          const vendorUpdates = { ...vendor };
-          delete vendorUpdates.vendor_type; // Don't change type
-          delete vendorUpdates.vendor_name; // Don't change name
-          vendorsToUpdate.push({ id: existingId, updates: vendorUpdates });
-        } else {
-          // Prepare for batch insert
-          vendorsToInsert.push({
-            wedding_id: membership.wedding_id,
-            ...vendor
-          });
+          if (existingId) {
+            // Prepare for batch update
+            const vendorUpdates = { ...vendor };
+            delete vendorUpdates.vendor_type; // Don't change type
+            delete vendorUpdates.vendor_name; // Don't change name
+            vendorsToUpdate.push({ id: existingId, updates: vendorUpdates });
+          } else {
+            // Prepare for batch insert
+            vendorsToInsert.push({
+              wedding_id: membership.wedding_id,
+              ...vendor
+            });
+          }
         }
-      }
 
-      // Batch insert new vendors
-      if (vendorsToInsert.length > 0) {
-        const { error: vendorInsertError } = await supabaseService
-          .from('vendor_tracker')
-          .insert(vendorsToInsert);
+        // Batch insert new vendors
+        if (vendorsToInsert.length > 0) {
+          const { error: vendorInsertError } = await supabaseService
+            .from('vendor_tracker')
+            .insert(vendorsToInsert);
 
-        if (vendorInsertError) {
-          console.error('Failed to batch insert vendors:', vendorInsertError);
+          if (vendorInsertError) {
+            logError('Failed to batch insert vendors', vendorInsertError);
+            validationNotes.push('I could not save some vendor updates just now. Please confirm them again later.');
+          }
         }
-      }
 
-      // Batch update existing vendors (Supabase doesn't support bulk update, so we update individually but in parallel)
-      if (vendorsToUpdate.length > 0) {
-        await Promise.all(
-          vendorsToUpdate.map(({ id, updates }) =>
-            supabaseService
-              .from('vendor_tracker')
-              .update(updates)
-              .eq('id', id)
-              .then(({ error }) => {
-                if (error) console.error('Failed to update vendor:', error);
-              })
-          )
-        );
+        // Batch update existing vendors (Supabase doesn't support bulk update, so we update individually but in parallel)
+        if (vendorsToUpdate.length > 0) {
+          await Promise.all(
+            vendorsToUpdate.map(({ id, updates }) =>
+              supabaseService
+                .from('vendor_tracker')
+                .update(updates)
+                .eq('id', id)
+                .then(({ error }) => {
+                  if (error) {
+                    logError('Failed to update vendor', error);
+                    validationNotes.push('Some vendor updates did not save. I will try again if you repeat them.');
+                  }
+                })
+            )
+          );
+        }
       }
     }
 
     // 3. Insert/Update budget items in budget_tracker table (BATCHED)
-    if (extractedData.budget_items && extractedData.budget_items.length > 0) {
+    if (processedPayload.budgetItems.length > 0) {
       // Fetch all existing budget items for this wedding in one query
-      const { data: existingBudgets } = await supabaseService
+      const { data: existingBudgets, error: existingBudgetsError } = await supabaseService
         .from('budget_tracker')
         .select('id, category, spent_amount')
         .eq('wedding_id', membership.wedding_id);
 
       const existingBudgetMap = new Map();
-      if (existingBudgets) {
+      if (existingBudgetsError) {
+        logError('Failed to load existing budget categories', existingBudgetsError);
+        validationNotes.push('I could not review your budget tracker, so I did not apply budget updates this time.');
+      } else if (existingBudgets) {
         existingBudgets.forEach(b => {
           existingBudgetMap.set(b.category, { id: b.id, spent_amount: b.spent_amount });
         });
@@ -372,88 +1038,146 @@ IMPORTANT:
       const budgetsToInsert = [];
       const budgetsToUpdate = [];
 
-      for (const budgetItem of extractedData.budget_items) {
-        const existing = existingBudgetMap.get(budgetItem.category);
+      if (!existingBudgetsError) {
+        for (const budgetItem of processedPayload.budgetItems) {
+          const existing = existingBudgetMap.get(budgetItem.category);
 
-        if (existing) {
-          // Prepare for batch update
-          const budgetUpdates = {};
+          if (existing) {
+            // Prepare for batch update
+            const budgetUpdates = {};
 
-          if (budgetItem.budgeted_amount !== null && budgetItem.budgeted_amount !== undefined) {
-            budgetUpdates.budgeted_amount = budgetItem.budgeted_amount;
+            if (budgetItem.budgeted_amount !== null && budgetItem.budgeted_amount !== undefined) {
+              budgetUpdates.budgeted_amount = budgetItem.budgeted_amount;
+            }
+
+            if (budgetItem.spent_amount !== null && budgetItem.spent_amount !== undefined) {
+              const newSpent = (existing.spent_amount || 0) + budgetItem.spent_amount;
+              if (budgetItem.spent_amount < 0) {
+                validationNotes.push(`Ignored negative spend for category "${budgetItem.category}".`);
+              } else if (newSpent < (existing.spent_amount || 0)) {
+                validationNotes.push(`Ignored spend decrease for category "${budgetItem.category}".`);
+              } else {
+                budgetUpdates.spent_amount = newSpent;
+              }
+            }
+
+            if (budgetItem.transaction_date) budgetUpdates.last_transaction_date = budgetItem.transaction_date;
+            if (budgetItem.transaction_amount) budgetUpdates.last_transaction_amount = budgetItem.transaction_amount;
+            if (budgetItem.transaction_description) {
+              budgetUpdates.last_transaction_description = budgetItem.transaction_description;
+            }
+            if (budgetItem.notes) budgetUpdates.notes = budgetItem.notes;
+
+            if (Object.keys(budgetUpdates).length > 0) {
+              budgetsToUpdate.push({ id: existing.id, updates: budgetUpdates });
+            }
+          } else {
+            // Prepare for batch insert
+            budgetsToInsert.push({
+              wedding_id: membership.wedding_id,
+              category: budgetItem.category,
+              budgeted_amount: budgetItem.budgeted_amount || 0,
+              spent_amount: budgetItem.spent_amount || 0,
+              last_transaction_date: budgetItem.transaction_date,
+              last_transaction_amount: budgetItem.transaction_amount,
+              last_transaction_description: budgetItem.transaction_description,
+              notes: budgetItem.notes
+            });
           }
-
-          if (budgetItem.spent_amount !== null && budgetItem.spent_amount !== undefined) {
-            budgetUpdates.spent_amount = (existing.spent_amount || 0) + budgetItem.spent_amount;
-          }
-
-          if (budgetItem.transaction_date) budgetUpdates.last_transaction_date = budgetItem.transaction_date;
-          if (budgetItem.transaction_amount) budgetUpdates.last_transaction_amount = budgetItem.transaction_amount;
-          if (budgetItem.transaction_description) budgetUpdates.last_transaction_description = budgetItem.transaction_description;
-          if (budgetItem.notes) budgetUpdates.notes = budgetItem.notes;
-
-          if (Object.keys(budgetUpdates).length > 0) {
-            budgetsToUpdate.push({ id: existing.id, updates: budgetUpdates });
-          }
-        } else {
-          // Prepare for batch insert
-          budgetsToInsert.push({
-            wedding_id: membership.wedding_id,
-            category: budgetItem.category,
-            budgeted_amount: budgetItem.budgeted_amount || 0,
-            spent_amount: budgetItem.spent_amount || 0,
-            last_transaction_date: budgetItem.transaction_date,
-            last_transaction_amount: budgetItem.transaction_amount,
-            last_transaction_description: budgetItem.transaction_description,
-            notes: budgetItem.notes
-          });
         }
-      }
 
-      // Batch insert new budget items
-      if (budgetsToInsert.length > 0) {
-        const { error: budgetInsertError } = await supabaseService
-          .from('budget_tracker')
-          .insert(budgetsToInsert);
+        // Batch insert new budget items
+        if (budgetsToInsert.length > 0) {
+          const { error: budgetInsertError } = await supabaseService
+            .from('budget_tracker')
+            .insert(budgetsToInsert);
 
-        if (budgetInsertError) {
-          console.error('Failed to batch insert budgets:', budgetInsertError);
+          if (budgetInsertError) {
+            logError('Failed to batch insert budgets', budgetInsertError);
+            validationNotes.push('I was unable to add some budget updates. Please resend them if needed.');
+          }
         }
-      }
 
-      // Batch update existing budget items (in parallel)
-      if (budgetsToUpdate.length > 0) {
-        await Promise.all(
-          budgetsToUpdate.map(({ id, updates }) =>
-            supabaseService
-              .from('budget_tracker')
-              .update(updates)
-              .eq('id', id)
-              .then(({ error }) => {
-                if (error) console.error('Failed to update budget:', error);
-              })
-          )
-        );
+        // Batch update existing budget items (in parallel)
+        if (budgetsToUpdate.length > 0) {
+          await Promise.all(
+            budgetsToUpdate.map(({ id, updates }) =>
+              supabaseService
+                .from('budget_tracker')
+                .update(updates)
+                .eq('id', id)
+                .then(({ error }) => {
+                  if (error) {
+                    logError('Failed to update budget', error);
+                    validationNotes.push('One of the budget updates did not save properly. Let me know if you would like to try again.');
+                  }
+                })
+            )
+          );
+        }
       }
     }
 
     // 4. Insert tasks in wedding_tasks table (BATCHED)
-    if (extractedData.tasks && extractedData.tasks.length > 0) {
-      const tasksToInsert = extractedData.tasks.map(task => ({
-        wedding_id: membership.wedding_id,
-        ...task
-      }));
-
-      const { error: taskInsertError } = await supabaseService
+    let tasksForResponse = [];
+    if (processedPayload.tasks.length > 0) {
+      const { data: existingTasks, error: existingTasksError } = await supabaseService
         .from('wedding_tasks')
-        .insert(tasksToInsert);
+        .select('task_name, due_date')
+        .eq('wedding_id', membership.wedding_id);
 
-      if (taskInsertError) {
-        console.error('Failed to batch insert tasks:', taskInsertError);
+      if (existingTasksError) {
+        logError('Failed to read existing tasks', existingTasksError);
+        validationNotes.push('I could not review your current task list, so I skipped adding new tasks this time.');
+      } else {
+        const existingTaskKeys = new Set();
+        if (existingTasks) {
+          existingTasks.forEach(task => {
+            if (!task?.task_name) return;
+            const key = taskDeterministicId(task.task_name, task.due_date || undefined);
+            existingTaskKeys.add(key);
+          });
+        }
+
+        const tasksToInsert = [];
+
+        for (const task of processedPayload.tasks) {
+          const key = taskDeterministicId(task.task_name, task.due_date || undefined);
+          if (existingTaskKeys.has(key)) {
+            validationNotes.push(`"${task.task_name}" is already on the task list, so I skipped adding it again.`);
+            continue;
+          }
+
+          existingTaskKeys.add(key);
+          tasksToInsert.push({
+            wedding_id: membership.wedding_id,
+            ...task
+          });
+        }
+
+        if (tasksToInsert.length > 0) {
+          const { error: taskInsertError } = await supabaseService
+            .from('wedding_tasks')
+            .insert(tasksToInsert);
+
+          if (taskInsertError) {
+            logError('Failed to batch insert tasks', taskInsertError);
+            validationNotes.push('I could not add some tasks right now. Please let me know if you want me to try again.');
+          } else {
+            tasksForResponse = tasksToInsert.map(({ wedding_id: _ignoredWeddingId, ...task }) => task);
+          }
+        }
       }
     }
 
     assistantMessage += trialWarning;
+
+    if (validationNotes.length > 0) {
+      const uniqueNotes = Array.from(new Set(validationNotes));
+      assistantMessage += `\n\nℹ️ I reviewed the details before saving. A few items need clarification:\n${uniqueNotes
+        .map(note => `• ${note}`)
+        .join('\n')}`;
+    }
 
     // Save messages to chat_messages table
     try {
@@ -469,7 +1193,7 @@ IMPORTANT:
         });
 
       if (userMsgError) {
-        console.error('Failed to save user message:', userMsgError);
+        logError('Failed to save user message', userMsgError);
       }
 
       // Save assistant message
@@ -484,10 +1208,10 @@ IMPORTANT:
         });
 
       if (assistantMsgError) {
-        console.error('Failed to save assistant message:', assistantMsgError);
+        logError('Failed to save assistant message', assistantMsgError);
       }
     } catch (saveError) {
-      console.error('Error saving chat messages:', saveError);
+      logError('Error saving chat messages', saveError);
       // Don't fail the request if saving fails
     }
 
@@ -495,12 +1219,18 @@ IMPORTANT:
       response: assistantMessage,
       conversationId: conversationId || 'temp',
       daysLeftInTrial: daysLeft,
-      extractedData: extractedData // For debugging
+      processedPayload: {
+        wedding_info: processedPayload.weddingInfo,
+        vendors: processedPayload.vendors,
+        budget_items: processedPayload.budgetItems,
+        tasks: tasksForResponse.length > 0 ? tasksForResponse : processedPayload.tasks,
+        warnings: processedPayload.warnings
+      }
     });
 
   } catch (error) {
     // Security: Only log error message, not full error object (may contain user messages, wedding data, user/wedding IDs)
-    console.error('Chat error:', error.message || 'Unknown error');
+    logError('Chat error', error);
     return res.status(500).json({ error: error.message || 'Chat processing failed' });
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node scripts/test-process-claude-payload.js",
     "build": "npm run build:config",
     "preview": "node preview.js",
     "build:config": "node scripts/build-config.js",

--- a/scripts/test-process-claude-payload.js
+++ b/scripts/test-process-claude-payload.js
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import { processClaudePayload, MAX_EXTRACTED_JSON_CHARS } from '../api/chat.js';
+
+function runTests() {
+  // Valid payload normalization
+  const validPayload = processClaudePayload(
+    JSON.stringify({
+      wedding_info: {
+        wedding_time: '5:30pm',
+        wedding_date: '2025-09-20',
+        expected_guest_count: '150',
+        total_budget: '$25,000'
+      },
+      vendors: [
+        {
+          vendor_type: 'photo',
+          vendor_name: 'Lens & Co',
+          total_cost: '$3000',
+          status: 'Booked'
+        }
+      ],
+      budget_items: [
+        {
+          category: 'flowers',
+          spent_amount: '$450'
+        }
+      ],
+      tasks: [
+        {
+          task_name: 'Send invites',
+          category: 'invitations',
+          status: 'in_progress',
+          due_date: '2025-05-01'
+        },
+        {
+          task_name: 'Send invites',
+          category: 'invitations',
+          status: 'in_progress',
+          due_date: '2025-05-01'
+        }
+      ]
+    })
+  );
+
+  assert.equal(validPayload.parseError, null, 'Valid payload should not produce parse errors');
+  assert.equal(validPayload.weddingInfo.wedding_time, '17:30', 'Time should normalize to 24-hour clock');
+  assert.equal(validPayload.weddingInfo.expected_guest_count, 150, 'Guest count should become integer');
+  assert.equal(validPayload.weddingInfo.total_budget, 25000, 'Budget should normalize to integer dollars');
+  assert.equal(validPayload.vendors.length, 1, 'Duplicate vendors should be filtered');
+  assert.equal(validPayload.vendors[0].vendor_type, 'photographer', 'Vendor type should canonicalize');
+  assert.equal(validPayload.budgetItems.length, 1, 'Budget item should remain');
+  assert.equal(validPayload.tasks.length, 1, 'Duplicate tasks should be removed');
+
+  // Invalid JSON handling
+  const invalidPayload = processClaudePayload('{bad json');
+  assert.ok(invalidPayload.parseError instanceof Error, 'Invalid JSON should surface parse error');
+  assert.ok(
+    invalidPayload.warnings.some(note => note.includes('could not read')),
+    'Invalid JSON should generate a user-facing warning'
+  );
+
+  // Missing sections should default safely
+  const emptyPayload = processClaudePayload(JSON.stringify({}));
+  assert.deepEqual(emptyPayload.weddingInfo, {}, 'Empty wedding info should remain empty object');
+  assert.deepEqual(emptyPayload.vendors, [], 'Empty vendors array expected');
+  assert.deepEqual(emptyPayload.tasks, [], 'Empty tasks array expected');
+
+  // Large payload should be rejected early
+  const oversized = 'x'.repeat(MAX_EXTRACTED_JSON_CHARS + 1);
+  const oversizedResult = processClaudePayload(oversized);
+  assert.equal(oversizedResult.parseError, null, 'Oversized payload should not attempt parse');
+  assert.ok(
+    oversizedResult.warnings.some(note => note.includes('very large set of details')),
+    'Oversized payload should warn about size limit'
+  );
+
+  console.log('All chat payload validation tests passed.');
+}
+
+try {
+  runTests();
+  process.exit(0);
+} catch (error) {
+  console.error('Chat payload validation tests failed:', error);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- export the processClaudePayload utilities and require vendor, budget, and task writes to pass Supabase lookups before saving
- add user-facing validation notes when database actions fail, skip duplicate tasks with deterministic keys, and keep sanitized task echoes aligned with saved records
- wire up a lightweight Node test harness for processClaudePayload and run it via the npm test script

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_6907d6b2364c8320a915a06c62e0e5fd