### PR TITLE
Create Creator Buddy development branch

### DIFF
--- a/api/router.js
+++ b/api/router.js
@@ -1,0 +1,30 @@
+// BuddyOS Router — routes chat requests to domain-specific buddy handlers
+
+import { buildCreatorPrompt } from "../buddies/creator/prompts.js";
+
+// Handler mapping for different buddy domains
+const handlers = {
+  bride: handleBrideBuddy,
+  creator: async (message) => {
+    // Placeholder route for Creator Buddy
+    // TODO: Replace placeholder response with real Creator Buddy chat handler later.
+    return { role: "assistant", content: `Creator Buddy received: ${message}` };
+  },
+};
+
+// Placeholder for Bride Buddy handler
+// TODO: Import actual Bride Buddy chat handler
+async function handleBrideBuddy(message) {
+  return { role: "assistant", content: `Bride Buddy received: ${message}` };
+}
+
+// Main router function
+export async function routeBuddyRequest(domain, message, context = {}) {
+  const handler = handlers[domain];
+
+  if (!handler) {
+    throw new Error(`Unknown buddy domain: ${domain}`);
+  }
+
+  return await handler(message, context);
+}

--- a/buddies/creator/adapters.js
+++ b/buddies/creator/adapters.js
@@ -1,0 +1,4 @@
+// Adapter layer connecting Creator Buddy domain to Buddy Core
+
+export * from "./domain.js";
+export * from "./prompts.js";

--- a/buddies/creator/domain.js
+++ b/buddies/creator/domain.js
@@ -1,0 +1,10 @@
+// Creator Buddy domain constants — remain localized until schema abstraction.
+
+// TODO: Populate with content-creation tool categories (video, writing, social, design)
+export const creatorTaskCategories = {};
+
+// TODO: Add tool recommendations for creators (video editing, design tools, social schedulers, etc.)
+export const creatorToolRecommendations = {};
+
+// TODO: Add empathy phrases like "Let's get your creative momentum going again."
+export const empathyStrings = {};

--- a/buddies/creator/prompts.js
+++ b/buddies/creator/prompts.js
@@ -1,0 +1,14 @@
+import { buildPrompt } from '../../buddy-core/prompts/templates.js';
+
+// BuddyOS Prompt Builder for Creator Buddy
+// TODO: Customize persona for AI-savvy creator support
+
+export function buildCreatorPrompt(ctx) {
+  // TODO: Customize persona for AI-savvy creator support
+  return buildPrompt({
+    persona: "You're Creator Buddy — upbeat, collaborative, practical. You help creators plan and use AI tools to produce, publish, and grow.",
+    domainContext: "content creation, social media, monetization, creative flow",
+    empathyDirectives: ["encourage experimentation", "balance productivity and joy"],
+    extractionSchema: ctx.extractionSchema
+  });
+}


### PR DESCRIPTION
Add Creator Buddy domain structure following Buddy Core architecture:
- buddies/creator/domain.js: placeholder domain constants with TODOs
- buddies/creator/prompts.js: buildCreatorPrompt using Buddy Core templates
- buddies/creator/adapters.js: adapter layer for domain integration

Create BuddyOS router for multi-domain buddy routing:
- api/router.js: routes chat requests to bride/creator buddy handlers
- Includes placeholder handlers for both domains
- Ready for integration with actual chat handlers

All files include TODO comments for future implementation.